### PR TITLE
Add option to control timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ CRAN-RELEASE
 cran-comments.md
 /doc/
 /Meta/
-/dev/
+/cachetest/
 docs
 CRAN-SUBMISSION
 .github/pkg.lock

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -154,7 +154,6 @@ references:
     given-names: Trent
   - family-names: Davis
     given-names: Trevor
-    orcid: https://orcid.org/0000-0001-6341-4639
   year: '2026'
   doi: 10.32614/CRAN.package.rappdirs
   version: '>= 0.3.0'
@@ -173,6 +172,19 @@ references:
   doi: 10.32614/CRAN.package.sf
   version: '>= 1.0.0'
 - type: software
+  title: testthat
+  abstract: 'testthat: Unit Testing for R'
+  notes: Imports
+  url: https://testthat.r-lib.org
+  repository: https://CRAN.R-project.org/package=testthat
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  year: '2026'
+  doi: 10.32614/CRAN.package.testthat
+  version: '>= 3.0.0'
+- type: software
   title: tibble
   abstract: 'tibble: Simple Data Frames'
   notes: Imports
@@ -188,6 +200,16 @@ references:
     email: hadley@rstudio.com
   year: '2026'
   doi: 10.32614/CRAN.package.tibble
+- type: software
+  title: tools
+  abstract: 'R: A Language and Environment for Statistical Computing'
+  notes: Imports
+  authors:
+  - name: R Core Team
+  institution:
+    name: R Foundation for Statistical Computing
+    address: Vienna, Austria
+  year: '2026'
 - type: software
   title: utils
   abstract: 'R: A Language and Environment for Statistical Computing'
@@ -314,16 +336,28 @@ references:
   year: '2026'
   doi: 10.32614/CRAN.package.quarto
 - type: software
-  title: testthat
-  abstract: 'testthat: Unit Testing for R'
+  title: withr
+  abstract: 'withr: Run Code ''With'' Temporarily Modified Global State'
   notes: Suggests
-  url: https://testthat.r-lib.org
-  repository: https://CRAN.R-project.org/package=testthat
+  url: https://withr.r-lib.org
+  repository: https://CRAN.R-project.org/package=withr
   authors:
+  - family-names: Hester
+    given-names: Jim
+  - family-names: Henry
+    given-names: Lionel
+    email: lionel@posit.co
+  - family-names: Müller
+    given-names: Kirill
+    email: krlmlr+r@mailbox.org
+  - family-names: Ushey
+    given-names: Kevin
+    email: kevinushey@gmail.com
   - family-names: Wickham
     given-names: Hadley
     email: hadley@posit.co
+  - family-names: Chang
+    given-names: Winston
   year: '2026'
-  doi: 10.32614/CRAN.package.testthat
-  version: '>= 3.0.0'
+  doi: 10.32614/CRAN.package.withr
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,9 @@ Imports:
     lifecycle,
     rappdirs (>= 0.3.0),
     sf (>= 1.0.0),
+    testthat (>= 3.0.0),
     tibble,
+    tools,
     utils
 Suggests:
     dplyr,
@@ -36,7 +38,7 @@ Suggests:
     ggplot2 (>= 3.5.0),
     knitr,
     quarto,
-    testthat (>= 3.0.0)
+    withr
 VignetteBuilder: 
     quarto
 Config/Needs/website: ropengov/rogtemplate, ragg, reactable, styler,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,9 @@
 
 -   Use `testthat::local_mocked_bindings()` on API error testing.
 -   Adapt vignettes to Quarto.
--   Query timeout can be controlled with `options(gisco_timeout)` ( Default
-    value: 30 seconds). Check `httr2::req_timeout()` for details (#123).
+-   Query timeout can be controlled with `options(gisco_timeout)` using
+    `httr2::req_timeout()`. Default value is
+    `httr2::req_timeout(..., seconds = 300)` (5 minutes) (#123).
 
 # giscoR 1.0.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 -   Use `testthat::local_mocked_bindings()` on API error testing.
 -   Adapt vignettes to Quarto.
+-   Query timeout can be controlled with `options(gisco_timeout)` ( Default
+    value: 30 seconds). Check `httr2::req_timeout()` for details (#123).
 
 # giscoR 1.0.1
 

--- a/R/docs.R
+++ b/R/docs.R
@@ -46,6 +46,7 @@ docs_id_years <- function(endpoint) {
   )
 
   req <- httr2::request(apiurl)
+  req <- httr2::req_timeout(req, getOption("gisco_timeout", 300L))
   req <- httr2::req_error(req, is_error = function(x) {
     FALSE
   })

--- a/R/gisco-check-access.R
+++ b/R/gisco-check-access.R
@@ -21,6 +21,7 @@ gisco_check_access <- function() {
 
   req <- httr2::request("https://gisco-services.ec.europa.eu/distribution/v2/")
   req <- httr2::req_url_path_append(req, "themes.json")
+  req <- httr2::req_timeout(req, getOption("gisco_timeout", 300L))
   req <- httr2::req_error(req, is_error = function(x) {
     FALSE
   })

--- a/R/gisco-get-cached-db.R
+++ b/R/gisco-get-cached-db.R
@@ -203,6 +203,7 @@ scrap_api_data <- function(entry_point) {
     max_size = 1024^3 / 2,
     max_age = 3600
   )
+  req <- httr2::req_timeout(req, getOption("gisco_timeout", 300L))
   req <- httr2::req_error(req, is_error = function(x) {
     FALSE
   })
@@ -245,6 +246,7 @@ scrap_api_data <- function(entry_point) {
       max_size = 1024^3 / 2,
       max_age = 3600
     )
+    req <- httr2::req_timeout(req, getOption("gisco_timeout", 300L))
     req <- httr2::req_error(req, is_error = function(x) {
       FALSE
     })

--- a/R/utils-url.R
+++ b/R/utils-url.R
@@ -175,7 +175,7 @@ download_url <- function(
     max_age = 3600
   )
 
-  req <- httr2::req_timeout(req, 300)
+  req <- httr2::req_timeout(req, getOption("gisco_timeout", 300L))
   req <- httr2::req_retry(req, max_tries = 3)
   if (verbose) {
     req <- httr2::req_progress(req)
@@ -255,6 +255,7 @@ get_request_body <- function(url, verbose = TRUE) {
   make_msg("info", verbose, msg)
 
   req <- httr2::request(url)
+  req <- httr2::req_timeout(req, getOption("gisco_timeout", 300L))
   req <- httr2::req_error(req, is_error = function(x) {
     FALSE
   })

--- a/codemeta.json
+++ b/codemeta.json
@@ -14,7 +14,7 @@
     "name": "R",
     "url": "https://r-project.org"
   },
-  "runtimePlatform": "R version 4.5.2 (2025-10-31 ucrt)",
+  "runtimePlatform": "R version 4.5.2 (2025-10-31)",
   "provider": {
     "@id": "https://cran.r-project.org",
     "@type": "Organization",
@@ -120,16 +120,15 @@
     },
     {
       "@type": "SoftwareApplication",
-      "identifier": "testthat",
-      "name": "testthat",
-      "version": ">= 3.0.0",
+      "identifier": "withr",
+      "name": "withr",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
         "name": "Comprehensive R Archive Network (CRAN)",
         "url": "https://cran.r-project.org"
       },
-      "sameAs": "https://CRAN.R-project.org/package=testthat"
+      "sameAs": "https://CRAN.R-project.org/package=withr"
     }
   ],
   "softwareRequirements": {
@@ -228,6 +227,19 @@
     },
     "9": {
       "@type": "SoftwareApplication",
+      "identifier": "testthat",
+      "name": "testthat",
+      "version": ">= 3.0.0",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=testthat"
+    },
+    "10": {
+      "@type": "SoftwareApplication",
       "identifier": "tibble",
       "name": "tibble",
       "provider": {
@@ -238,7 +250,12 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=tibble"
     },
-    "10": {
+    "11": {
+      "@type": "SoftwareApplication",
+      "identifier": "tools",
+      "name": "tools"
+    },
+    "12": {
       "@type": "SoftwareApplication",
       "identifier": "utils",
       "name": "utils"
@@ -248,7 +265,7 @@
   "applicationCategory": "cartography",
   "isPartOf": "http://ropengov.org/",
   "keywords": ["ropengov", "r", "spatial", "api-wrapper", "rstats", "r-package", "eurostat", "gisco", "thematic-maps", "eurostat-data", "cran", "ggplot2", "gis", "cran-r"],
-  "fileSize": "1924.39KB",
+  "fileSize": "2983.63KB",
   "citation": [
     {
       "@type": "SoftwareSourceCode",

--- a/dev/config_attachment.yaml
+++ b/dev/config_attachment.yaml
@@ -1,0 +1,14 @@
+path.n: NAMESPACE
+path.d: DESCRIPTION
+dir.r: R
+dir.v: vignettes
+dir.t: tests
+extra.suggests:
+  - quarto
+  - eurostat
+pkg_ignore: rmarkdown
+document: yes
+normalize: yes
+inside_rmd: no
+must.exist: yes
+check_if_suggests_is_installed: yes

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -44,6 +44,7 @@ codebase
 codecov
 colorspace
 der
+doi
 eurostat
 geocoded
 geocoding

--- a/inst/schemaorg.json
+++ b/inst/schemaorg.json
@@ -38,7 +38,7 @@
         "name": "Comprehensive R Archive Network (CRAN)",
         "url": "https://cran.r-project.org"
       },
-      "runtimePlatform": "R version 4.5.2 (2025-10-31 ucrt)",
+      "runtimePlatform": "R version 4.5.2 (2025-10-31)",
       "version": "1.0.1.9000"
     },
     {

--- a/tests/testthat/test-utils-url.R
+++ b/tests/testthat/test-utils-url.R
@@ -351,7 +351,7 @@ test_that("Test timeout", {
   withr::local_options(gisco_timeout = 0.01)
   expect_error(
     download_url(url = url, verbose = FALSE, cache_dir = cdir),
-    "Failed to perform HTTP request(.*)Timeout(.*)after 10 milliseconds"
+    "Failed to perform HTTP request(.*)Timeout(.*)after(.*)milliseconds"
   )
 
   withr::local_options(gisco_timeout = 300L)

--- a/tests/testthat/test-utils-url.R
+++ b/tests/testthat/test-utils-url.R
@@ -333,3 +333,33 @@ test_that("Test import jsonlite", {
   expect_silent(p <- for_import_jsonlite())
   expect_null(for_import_jsonlite())
 })
+
+test_that("Test timeout", {
+  skip_on_cran()
+  skip_if_gisco_offline()
+
+  cdir <- file.path(tempdir(), "testthat_timeout")
+  if (dir.exists(cdir)) {
+    unlink(cdir, recursive = TRUE, force = TRUE)
+  }
+
+  url <- paste0(
+    "https://gisco-services.ec.europa.eu/distribution/v2/",
+    "countries/geojson/CNTR_BN_20M_2020_4326.geojson"
+  )
+
+  withr::local_options(gisco_timeout = 0.01)
+  expect_error(
+    download_url(url = url, verbose = FALSE, cache_dir = cdir),
+    "Failed to perform HTTP request(.*)Timeout(.*)after 10 milliseconds"
+  )
+
+  withr::local_options(gisco_timeout = 300L)
+  expect_silent(
+    ff <- download_url(url = url, verbose = FALSE, cache_dir = cdir)
+  )
+
+  expect_true(file.exists(ff))
+  unlink(cdir, recursive = TRUE, force = TRUE)
+  expect_false(file.exists(ff))
+})


### PR DESCRIPTION
Default timeout value is 300 seconds `getOption("gisco_timeout", 300L)`  , can be controlled with `options(gisco_timeout)` (e.g. `options(gisco_timeout = 0.01)` == 10 milliseconds).

Close #123 