### PR TITLE
Refactor test cache isolation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,9 +10,6 @@ license: GPL-3.0-only
 title: 'giscoR: Download ''Eurostat'' ''GISCO'' Spatial Data'
 version: 1.1.1.9000
 doi: 10.32614/CRAN.package.giscoR
-identifiers:
-- type: doi
-  value: 10.32614/CRAN.package.giscoR
 abstract: Tools to download global and European spatial data from the 'Eurostat' 'GISCO'
   (Geographic Information System of the Commission) data distribution <https://ec.europa.eu/eurostat/web/gisco>.
   The package provides helpers for country boundaries, 'NUTS' regions, administrative
@@ -40,7 +37,6 @@ preferred-citation:
     The package provides helpers for country boundaries, NUTS regions, administrative
     units, statistical units, transport networks, basic service locations and other
     GISCO datasets. This package is not officially related to or endorsed by Eurostat.
-repository: https://CRAN.R-project.org/package=giscoR
 repository-code: https://github.com/rOpenGov/giscoR
 url: https://ropengov.github.io/giscoR/
 contact:
@@ -323,7 +319,6 @@ references:
   abstract: 'quarto: R Interface to ''Quarto'' Markdown Publishing System'
   notes: Suggests
   url: https://quarto-dev.github.io/quarto-r/
-  repository: https://CRAN.R-project.org/package=quarto
   authors:
   - family-names: Allaire
     given-names: JJ
@@ -334,7 +329,6 @@ references:
     email: cderv@posit.co
     orcid: https://orcid.org/0000-0003-4474-2498
   year: '2026'
-  doi: 10.32614/CRAN.package.quarto
 - type: software
   title: stats
   abstract: 'R: A Language and Environment for Statistical Computing'

--- a/R/docs.R
+++ b/R/docs.R
@@ -41,11 +41,7 @@ db_values <- function(id, field, decreasing = FALSE, formatted = TRUE) {
 #' A character string with the available years for the specified endpoint.
 #' @noRd
 docs_id_years <- function(endpoint) {
-  apiurl <- paste0(
-    gisco_id_url(),
-    endpoint,
-    "?year=9999"
-  )
+  apiurl <- paste0(gisco_id_url(), endpoint, "?year=9999")
 
   req <- gisco_request(apiurl, cache = FALSE, retry = FALSE)
   resp <- gisco_perform_request(
@@ -57,7 +53,7 @@ docs_id_years <- function(endpoint) {
   if (is.null(resp)) {
     return("are unavailable")
   }
-  get_years <- httr2::resp_body_json(resp, simplifyVector = TRUE)
+  get_years <- gisco_resp_body_json(resp, simplifyVector = TRUE)
   get_years <- get_years$details
   available_years <- gsub("[^0-9]", " ", get_years)
   available_years <- unique(unlist(strsplit(available_years, " ")))

--- a/R/gisco-bulk-download.R
+++ b/R/gisco-bulk-download.R
@@ -153,12 +153,7 @@ gisco_bulk_download <- function(
   }
 
   api_entry <- bulk_download_api_entry(routes)
-  zipname <- build_bulk_zip_name(
-    id,
-    year,
-    make_params$resolution,
-    ext
-  )
+  zipname <- build_bulk_zip_name(id, year, make_params$resolution, ext)
   url <- file.path(api_entry, zipname)
   subdir <- bulk_download_subdir(id)
 

--- a/R/gisco-cache.R
+++ b/R/gisco-cache.R
@@ -122,10 +122,8 @@ gisco_set_cache_dir <- function(
   make_msg("info", verbose, msg)
 
   # Install the cache path in the environment variable.
-  # nocov start
-
   if (install) {
-    config_dir <- tools::R_user_dir("giscoR", "config")
+    config_dir <- gisco_user_dir("config")
     # Create cache directory if not present.
 
     if (!dir.exists(config_dir)) {
@@ -143,7 +141,6 @@ gisco_set_cache_dir <- function(
         "You can overwrite it with {.arg overwrite} = {.val {TRUE}}."
       ))
     }
-    # nocov end
   } else {
     make_msg(
       "info",
@@ -224,10 +221,9 @@ gisco_clear_cache <- function(
 ) {
   migrate_cache()
 
-  config_dir <- tools::R_user_dir("giscoR", "config")
+  config_dir <- gisco_user_dir("config")
   data_dir <- detect_cache_dir_muted()
 
-  # nocov start
   if (config && dir.exists(config_dir)) {
     unlink(config_dir, recursive = TRUE, force = TRUE)
 
@@ -235,7 +231,6 @@ gisco_clear_cache <- function(
       cli::cli_alert_warning("Deleted {.pkg giscoR} cache configuration.")
     }
   }
-  # nocov end
   if (cached_data && dir.exists(data_dir)) {
     siz <- file.size(list.files(data_dir, recursive = TRUE, full.names = TRUE))
     siz <- sum(siz, na.rm = TRUE)
@@ -271,12 +266,8 @@ detect_cache_dir_muted <- function() {
 
   if (is.null(getvar) || is.na(getvar) || !nzchar(getvar)) {
     # If unset, try to retrieve the value from the cache config.
-    cache_config <- file.path(
-      tools::R_user_dir("giscoR", "config"),
-      "gisco_cache_dir"
-    )
+    cache_config <- file.path(gisco_user_dir("config"), "gisco_cache_dir")
 
-    # nocov start
     if (file.exists(cache_config)) {
       cached_path <- readLines(cache_config)
 
@@ -289,7 +280,6 @@ detect_cache_dir_muted <- function() {
       # Return the cached path.
       Sys.setenv(GISCO_CACHE_DIR = cached_path)
       cached_path
-      # nocov end
     } else {
       # Use the default cache location.
 
@@ -331,7 +321,7 @@ create_cache_dir <- function(cache_dir = NULL) {
 #' @noRd
 migrate_cache <- function(
   old = rappdirs::user_config_dir("giscoR", "R"),
-  new = tools::R_user_dir("giscoR", "config")
+  new = gisco_user_dir("config")
 ) {
   fname <- "gisco_cache_dir"
 
@@ -357,4 +347,14 @@ migrate_cache <- function(
   unlink(old, force = TRUE, recursive = TRUE)
 
   invisible()
+}
+
+#' Return a user directory for giscoR
+#'
+#' @param which Directory type passed to [tools::R_user_dir()].
+#' @return Path to the requested user directory.
+#'
+#' @noRd
+gisco_user_dir <- function(which = "config") {
+  tools::R_user_dir("giscoR", which)
 }

--- a/R/gisco-check-access.R
+++ b/R/gisco-check-access.R
@@ -20,11 +20,7 @@ gisco_check_access <- function() {
     return(FALSE)
   }
 
-  req <- gisco_request(
-    gisco_distribution_url(),
-    cache = FALSE,
-    retry = FALSE
-  )
+  req <- gisco_request(gisco_distribution_url(), cache = FALSE, retry = FALSE)
   req <- httr2::req_url_path_append(req, "themes.json")
   resp <- gisco_perform_request(
     req,

--- a/R/gisco-get-ports.R
+++ b/R/gisco-get-ports.R
@@ -61,10 +61,7 @@ gisco_get_ports <- function(
   year <- as.character(year)
   valid_years <- as.character(c(2013, 2009))
   year <- match_arg_pretty(year, valid_years)
-  files <- c(
-    "2009" = "PORT_2009_SH.zip",
-    "2013" = "PORT_2013_SH.zip"
-  )
+  files <- c("2009" = "PORT_2009_SH.zip", "2013" = "PORT_2013_SH.zip")
   url <- eurostat_gisco_geodata_url(files[[year]])
   data_sf <- read_gisco_dataset(
     url,

--- a/R/utils-request.R
+++ b/R/utils-request.R
@@ -58,10 +58,7 @@ gisco_request_fake_404 <- function(req) {
     return(req)
   }
 
-  httr2::req_url(
-    req,
-    paste0(gisco_distribution_url(), "fake")
-  )
+  httr2::req_url(req, paste0(gisco_distribution_url(), "fake"))
 }
 
 #' Handle an HTTP error response
@@ -186,6 +183,17 @@ call_gisco_json_api <- function(
     return(NULL)
   }
 
-  resp_json <- httr2::resp_body_json(resp, simplifyVector = TRUE)
+  resp_json <- gisco_resp_body_json(resp, simplifyVector = TRUE)
   tibble::as_tibble(resp_json[[result_field]])
+}
+
+#' Parse a response body as JSON
+#'
+#' @param resp An httr2 response.
+#' @param ... Arguments passed to [httr2::resp_body_json()].
+#'
+#' @return Parsed JSON response body.
+#' @noRd
+gisco_resp_body_json <- function(resp, ...) {
+  httr2::resp_body_json(resp, ...)
 }

--- a/R/utils-sf.R
+++ b/R/utils-sf.R
@@ -192,12 +192,7 @@ build_sf_filter_query <- function(file_local, filters, operator = "AND") {
   layer <- get_sf_layer_name(file_local)
   where <- Map(
     function(column, values) {
-      paste0(
-        column,
-        " IN (",
-        paste0("'", values, "'", collapse = ", "),
-        ")"
-      )
+      paste0(column, " IN (", paste0("'", values, "'", collapse = ", "), ")")
     },
     names(filters),
     filters

--- a/R/utils-units.R
+++ b/R/utils-units.R
@@ -84,11 +84,7 @@ get_unit_files <- function(
     year,
     "-units.json"
   )
-  api_entry <- paste0(
-    gisco_distribution_url(),
-    api_id,
-    "/distribution/"
-  )
+  api_entry <- paste0(gisco_distribution_url(), api_id, "/distribution/")
   cache_subdir <- file.path(dataset, "units")
   base_cache_dir <- create_cache_dir(cache_dir)
   db <- NULL

--- a/R/utils-url.R
+++ b/R/utils-url.R
@@ -166,10 +166,7 @@ gisco_pub_url <- function() {
 #' @return A character string with the full geodata file URL.
 #' @noRd
 eurostat_gisco_geodata_url <- function(filename) {
-  paste0(
-    "https://ec.europa.eu/eurostat/cache/GISCO/geodatafiles/",
-    filename
-  )
+  paste0("https://ec.europa.eu/eurostat/cache/GISCO/geodatafiles/", filename)
 }
 
 #' Internal function to download and cache a file from a URL
@@ -308,10 +305,20 @@ for_import_jsonlite <- function() {
   if (is.null(resp)) {
     return(invisible(NULL))
   }
-  txt <- httr2::resp_body_string(resp)
+  txt <- gisco_resp_body_string(resp)
   local <- jsonlite::parse_json(txt)
   local <- NULL
   invisible(local)
+}
+
+#' Parse a response body as a string
+#'
+#' @param resp An httr2 response.
+#'
+#' @return A character string with the response body.
+#' @noRd
+gisco_resp_body_string <- function(resp) {
+  httr2::resp_body_string(resp)
 }
 
 #' Wrapper for `is_online()` in tests

--- a/codemeta.json
+++ b/codemeta.json
@@ -4,7 +4,7 @@
   "identifier": "giscoR",
   "description": "Tools to download global and European spatial data from the 'Eurostat' 'GISCO' (Geographic Information System of the Commission) data distribution <https://ec.europa.eu/eurostat/web/gisco>. The package provides helpers for country boundaries, 'NUTS' regions, administrative units, statistical units, transport networks, basic service locations and other 'GISCO' datasets. This package is not officially related to or endorsed by 'Eurostat'.",
   "name": "giscoR: Download 'Eurostat' 'GISCO' Spatial Data",
-  "relatedLink": ["https://ropengov.github.io/giscoR/", "https://CRAN.R-project.org/package=giscoR"],
+  "relatedLink": "https://ropengov.github.io/giscoR/",
   "codeRepository": "https://github.com/rOpenGov/giscoR",
   "issueTracker": "https://github.com/rOpenGov/giscoR/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
@@ -15,12 +15,6 @@
     "url": "https://r-project.org"
   },
   "runtimePlatform": "R version 4.6.1 (2026-06-24 ucrt)",
-  "provider": {
-    "@id": "https://cran.r-project.org",
-    "@type": "Organization",
-    "name": "Comprehensive R Archive Network (CRAN)",
-    "url": "https://cran.r-project.org"
-  },
   "author": [
     {
       "@type": "Person",
@@ -60,63 +54,28 @@
     {
       "@type": "SoftwareApplication",
       "identifier": "dplyr",
-      "name": "dplyr",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=dplyr"
+      "name": "dplyr"
     },
     {
       "@type": "SoftwareApplication",
       "identifier": "eurostat",
-      "name": "eurostat",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=eurostat"
+      "name": "eurostat"
     },
     {
       "@type": "SoftwareApplication",
       "identifier": "ggplot2",
       "name": "ggplot2",
-      "version": ">= 3.5.0",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=ggplot2"
+      "version": ">= 3.5.0"
     },
     {
       "@type": "SoftwareApplication",
       "identifier": "knitr",
-      "name": "knitr",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=knitr"
+      "name": "knitr"
     },
     {
       "@type": "SoftwareApplication",
       "identifier": "quarto",
-      "name": "quarto",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=quarto"
+      "name": "quarto"
     },
     {
       "@type": "SoftwareApplication",
@@ -127,26 +86,12 @@
       "@type": "SoftwareApplication",
       "identifier": "testthat",
       "name": "testthat",
-      "version": ">= 3.0.0",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=testthat"
+      "version": ">= 3.0.0"
     },
     {
       "@type": "SoftwareApplication",
       "identifier": "withr",
-      "name": "withr",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=withr"
+      "name": "withr"
     }
   ],
   "softwareRequirements": {
@@ -159,102 +104,46 @@
     "2": {
       "@type": "SoftwareApplication",
       "identifier": "cli",
-      "name": "cli",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=cli"
+      "name": "cli"
     },
     "3": {
       "@type": "SoftwareApplication",
       "identifier": "countrycode",
       "name": "countrycode",
-      "version": ">= 1.2.0",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=countrycode"
+      "version": ">= 1.2.0"
     },
     "4": {
       "@type": "SoftwareApplication",
       "identifier": "httr2",
       "name": "httr2",
-      "version": ">= 1.2.0",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=httr2"
+      "version": ">= 1.2.0"
     },
     "5": {
       "@type": "SoftwareApplication",
       "identifier": "jsonlite",
-      "name": "jsonlite",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=jsonlite"
+      "name": "jsonlite"
     },
     "6": {
       "@type": "SoftwareApplication",
       "identifier": "lifecycle",
-      "name": "lifecycle",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=lifecycle"
+      "name": "lifecycle"
     },
     "7": {
       "@type": "SoftwareApplication",
       "identifier": "rappdirs",
       "name": "rappdirs",
-      "version": ">= 0.3.0",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=rappdirs"
+      "version": ">= 0.3.0"
     },
     "8": {
       "@type": "SoftwareApplication",
       "identifier": "sf",
       "name": "sf",
-      "version": ">= 1.0.0",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=sf"
+      "version": ">= 1.0.0"
     },
     "9": {
       "@type": "SoftwareApplication",
       "identifier": "tibble",
-      "name": "tibble",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=tibble"
+      "name": "tibble"
     },
     "10": {
       "@type": "SoftwareApplication",
@@ -271,7 +160,7 @@
   "applicationCategory": "cartography",
   "isPartOf": "http://ropengov.org/",
   "keywords": ["ropengov", "r", "spatial", "api-wrapper", "rstats", "r-package", "eurostat", "gisco", "thematic-maps", "eurostat-data", "cran", "ggplot2", "gis", "cran-r"],
-  "fileSize": "1971.726KB",
+  "fileSize": "1970.168KB",
   "citation": [
     {
       "@type": "SoftwareSourceCode",

--- a/inst/schemaorg.json
+++ b/inst/schemaorg.json
@@ -32,12 +32,6 @@
         "name": "R",
         "url": "https://r-project.org"
       },
-      "provider": {
-        "id": "https://cran.r-project.org",
-        "type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
       "runtimePlatform": "R version 4.6.1 (2026-06-24 ucrt)",
       "version": "1.1.1.9000"
     },

--- a/tests/testthat/_snaps/docs.md
+++ b/tests/testthat/_snaps/docs.md
@@ -1,4 +1,4 @@
-# Check docs
+# Dataset documentation includes current metadata
 
     Code
       db_values("communes", "year")
@@ -26,7 +26,7 @@
     Output
       [1] "BN"     "COASTL" "INLAND" "LB"     "RG"    
 
-# Check GISCO ID docs
+# GISCO ID documentation includes available years
 
     Code
       docs_id_years("nuts")

--- a/tests/testthat/_snaps/gisco-address-api.md
+++ b/tests/testthat/_snaps/gisco-address-api.md
@@ -1,4 +1,4 @@
-# Test offline
+# Address API returns NULL when offline
 
     Code
       fend <- gisco_address_api_bbox()

--- a/tests/testthat/_snaps/gisco-attributions.md
+++ b/tests/testthat/_snaps/gisco-attributions.md
@@ -1,4 +1,4 @@
-# Testing attributions
+# Attribution text is exposed as package data
 
     Code
       gisco_attributions(copyright = TRUE)

--- a/tests/testthat/_snaps/gisco-bulk-download.md
+++ b/tests/testthat/_snaps/gisco-bulk-download.md
@@ -1,4 +1,4 @@
-# Deprecations
+# Bulk download reports deprecated arguments
 
     Code
       s <- gisco_bulk_download(id_giscoR = "coastal_lines", resolution = 60,
@@ -17,7 +17,7 @@
       The `recursive` argument of `gisco_bulk_download()` is deprecated as of giscoR 1.0.0.
       i Child `.zip` files inside the top-level `.zip` will not be unzipped.
 
-# Errors
+# Bulk download validates user inputs
 
     Code
       gisco_bulk_download(id_giscoR = "nutes")

--- a/tests/testthat/_snaps/gisco-cache.md
+++ b/tests/testthat/_snaps/gisco-cache.md
@@ -1,4 +1,4 @@
-# Mock migration
+# Legacy cache configuration migrates to the current location
 
     Code
       migrate_cache(old = old, new = new)

--- a/tests/testthat/_snaps/gisco-get-cached-db.md
+++ b/tests/testthat/_snaps/gisco-get-cached-db.md
@@ -1,4 +1,4 @@
-# Test offline
+# Cached database returns NULL when offline
 
     Code
       fend <- gisco_get_cached_db(update_cache = TRUE)
@@ -6,7 +6,7 @@
       ! Could not access <https://gisco-services.ec.europa.eu/distribution/v2/>. If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
       > Returning "NULL".
 
-# Get database
+# Cached database refreshes from the remote metadata
 
     Code
       unique(new_db$id_giscor)

--- a/tests/testthat/_snaps/gisco-get-coastal-lines.md
+++ b/tests/testthat/_snaps/gisco-get-coastal-lines.md
@@ -1,4 +1,4 @@
-# Errors
+# Coastal lines validate unsupported extensions
 
     Code
       gisco_get_coastal_lines(ext = "docx")
@@ -6,7 +6,7 @@
       Error:
       ! `ext` must be "geojson", "gpkg", or "shp", not "docx".
 
-# Cached dataset vs updated
+# Coastal lines can refresh an existing cached dataset
 
     Code
       db_cached <- gisco_get_coastal_lines(verbose = TRUE)

--- a/tests/testthat/_snaps/gisco-get-communes.md
+++ b/tests/testthat/_snaps/gisco-get-communes.md
@@ -1,4 +1,4 @@
-# Deprecations
+# Communes report deprecated cache usage
 
     Code
       s <- gisco_get_communes(cache = FALSE, spatialtype = "LB")
@@ -7,7 +7,7 @@
       The `cache` argument of `gisco_get_communes()` is deprecated as of giscoR 1.0.0.
       i Results are always cached. To avoid persistent cache files, use `cache_dir = tempdir()`.
 
-# Extensions
+# Communes reject unsupported extensions and read GeoJSON
 
     Code
       gisco_get_communes(ext = "docx")

--- a/tests/testthat/_snaps/gisco-get-countries.md
+++ b/tests/testthat/_snaps/gisco-get-countries.md
@@ -1,11 +1,11 @@
-# Cached dataset vs updated
+# Countries can refresh an existing cached dataset
 
     Code
       db_cached <- gisco_get_countries(verbose = TRUE)
     Message
       i Loaded from `?giscoR::gisco_countries_2024()` dataset. Use `update_cache` = TRUE to reload from file.
 
-# Extensions
+# Countries support GeoJSON and zipped shapefile downloads
 
     Code
       gisco_get_countries(ext = "docx")

--- a/tests/testthat/_snaps/gisco-get-lau.md
+++ b/tests/testthat/_snaps/gisco-get-lau.md
@@ -1,4 +1,4 @@
-# Deprecations
+# LAU reports deprecated cache usage
 
     Code
       s <- gisco_get_lau(year = 2024, cache = TRUE, gisco_id = "ES_12016")
@@ -7,7 +7,7 @@
       The `cache` argument of `gisco_get_lau()` is deprecated as of giscoR 1.0.0.
       i Results are always cached. To avoid persistent cache files, use `cache_dir = tempdir()`.
 
-# Extensions
+# LAU rejects unsupported extensions and reads GeoJSON
 
     Code
       gisco_get_lau(ext = "docx")

--- a/tests/testthat/_snaps/gisco-get-metadata.md
+++ b/tests/testthat/_snaps/gisco-get-metadata.md
@@ -1,4 +1,4 @@
-# Test offline
+# Metadata returns NULL when offline
 
     Code
       fend <- gisco_get_metadata()
@@ -6,7 +6,7 @@
       x No internet connection available.
       > Returning "NULL".
 
-# Errors
+# Metadata validates dataset and year inputs
 
     Code
       gisco_get_metadata("grids")

--- a/tests/testthat/_snaps/gisco-get-nuts.md
+++ b/tests/testthat/_snaps/gisco-get-nuts.md
@@ -1,4 +1,4 @@
-# Valid inputs
+# NUTS validate extensions and level inputs
 
     Code
       gisco_get_nuts(ext = "docx")
@@ -14,7 +14,7 @@
       Error:
       ! `nuts_level` must be "all", "0", "1", "2", or "3", not "docx".
 
-# Cached dataset vs updated
+# NUTS can refresh an existing cached dataset
 
     Code
       db_cached <- gisco_get_nuts(verbose = TRUE, nuts_id = "ES51")

--- a/tests/testthat/_snaps/gisco-get-postal-codes.md
+++ b/tests/testthat/_snaps/gisco-get-postal-codes.md
@@ -1,4 +1,4 @@
-# Extensions
+# Postal codes reject unsupported extensions and read shapefiles
 
     Code
       gisco_get_postal_codes(ext = "docx")

--- a/tests/testthat/_snaps/gisco-get-unit-country.md
+++ b/tests/testthat/_snaps/gisco-get-unit-country.md
@@ -1,4 +1,4 @@
-# unit_country: Validate inputs
+# Country unit validates year, EPSG, resolution and spatial type
 
     Code
       gisco_get_unit_country(year = -1989)

--- a/tests/testthat/_snaps/gisco-get-unit-nuts.md
+++ b/tests/testthat/_snaps/gisco-get-unit-nuts.md
@@ -1,4 +1,4 @@
-# unit_nuts: Validate inputs
+# NUTS unit validates year, EPSG, resolution and spatial type
 
     Code
       gisco_get_unit_nuts(year = -1989)

--- a/tests/testthat/_snaps/gisco-get-unit-urban-audit.md
+++ b/tests/testthat/_snaps/gisco-get-unit-urban-audit.md
@@ -1,4 +1,4 @@
-# unit_urban_audit: Validate inputs
+# Urban audit unit validates year, EPSG and spatial type
 
     Code
       gisco_get_unit_urban_audit(year = -1989)

--- a/tests/testthat/_snaps/gisco-get-urban-audit.md
+++ b/tests/testthat/_snaps/gisco-get-urban-audit.md
@@ -1,4 +1,4 @@
-# Test inputs
+# Urban audit validates extensions and level inputs
 
     Code
       gisco_get_urban_audit(ext = "docx")

--- a/tests/testthat/_snaps/gisco-id-api.md
+++ b/tests/testthat/_snaps/gisco-id-api.md
@@ -1,4 +1,4 @@
-# Test offline
+# ID API returns NULL when offline
 
     Code
       fend <- gisco_id_api_geonames(x = 4, y = 52)

--- a/tests/testthat/_snaps/utils-country.md
+++ b/tests/testthat/_snaps/utils-country.md
@@ -1,4 +1,4 @@
-# Utils names
+# Country code conversion handles standard names and codes
 
     Code
       convert_country_code(c("Espagne", "United Kingdom"))
@@ -30,7 +30,7 @@
     Output
       [1] "ES" "DE"
 
-# Problematic names
+# Country code conversion reports unresolved names
 
     Code
       convert_country_code(c("Espagne", "Antartica"))
@@ -96,7 +96,7 @@
     Output
       [1] "XKX"
 
-# Test mixed countries
+# Country filters accept mixed country identifiers
 
     Code
       convert_country_code(c("Germany", "USA", "Greece", "united Kingdom"))

--- a/tests/testthat/_snaps/utils-url.md
+++ b/tests/testthat/_snaps/utils-url.md
@@ -1,4 +1,4 @@
-# Test offline
+# Downloads return NULL when offline
 
     Code
       fend <- download_url(url, cache_dir = cdir, subdir = "fixme", update_cache = FALSE,
@@ -7,7 +7,7 @@
       x No internet connection available.
       > Returning "NULL".
 
-# Get urls
+# URL database lookup validates and returns matching entries
 
     Code
       get_url_db("communes", "9999", fn = "gisco_get_communes")
@@ -27,7 +27,7 @@
       * `ext` = "csv"
       i Check available combinations in `giscoR::gisco_get_cached_db()`.
 
-# No connection body
+# Request body returns NULL when offline
 
     Code
       fend <- get_request_body(url, verbose = FALSE)
@@ -35,7 +35,7 @@
       x No internet connection available.
       > Returning "NULL".
 
-# Error body
+# Request body returns NULL for 404 responses
 
     Code
       fend <- get_request_body(url, verbose = FALSE)

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -1,4 +1,4 @@
-# Messages
+# Message helper emits each supported message type
 
     Code
       make_msg("generic", TRUE, "Hi", "I am a generic.", "See {.var avar}.")
@@ -33,7 +33,7 @@
     Message
       v Hooray! 5/5 ;)
 
-# Pretty match
+# Argument matcher reports exact and invalid values
 
     Code
       my_fun("error here")
@@ -108,7 +108,7 @@
       The `cache` argument of `x()` is deprecated as of giscoR 1.0.0.
       i Results are always cached. To avoid persistent cache files, use `cache_dir = tempdir()`.
 
-# Test cli_abort_if_not
+# cli_abort_if_not aborts when conditions fail
 
     Code
       cli_abort_if_not(`Message supports {.cls inline} {.str markup}.` = is.logical(1))

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -7,3 +7,12 @@ skip_if_gisco_offline <- function() {
 
   invisible()
 }
+
+local_test_cache_dir <- function(pattern = "gisco-test-") {
+  path <- withr::local_tempdir(pattern = pattern, .local_envir = parent.frame())
+  withr::defer(
+    unlink(path, recursive = TRUE, force = TRUE),
+    envir = parent.frame()
+  )
+  path
+}

--- a/tests/testthat/setup-cache.R
+++ b/tests/testthat/setup-cache.R
@@ -1,0 +1,8 @@
+.gisco_test_cache_dir <- withr::local_tempdir(
+  pattern = "giscoR-test-cache-",
+  .local_envir = testthat::teardown_env()
+)
+withr::local_envvar(
+  GISCO_CACHE_DIR = .gisco_test_cache_dir,
+  .local_envir = testthat::teardown_env()
+)

--- a/tests/testthat/test-docs.R
+++ b/tests/testthat/test-docs.R
@@ -1,4 +1,4 @@
-test_that("Check docs", {
+test_that("Dataset documentation includes current metadata", {
   skip_on_cran()
   skip_if_gisco_offline()
   # Load databases now
@@ -10,7 +10,7 @@ test_that("Check docs", {
   expect_snapshot(db_values("communes", "spatialtype", formatted = FALSE))
 })
 
-test_that("Check GISCO ID docs", {
+test_that("GISCO ID documentation includes available years", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -19,25 +19,18 @@ test_that("Check GISCO ID docs", {
 })
 
 test_that("GISCO ID docs handle unavailable API", {
-  local_mocked_bindings(
-    gisco_perform_request = function(...) NULL
-  )
+  local_mocked_bindings(gisco_perform_request = function(...) NULL)
 
   expect_identical(docs_id_years("nuts"), "are unavailable")
 })
 
 test_that("GISCO ID docs use singular wording for one available year", {
-  local_mocked_bindings(
-    gisco_perform_request = function(...) {
-      structure(list(), class = "mock_response")
-    }
-  )
-  local_mocked_bindings(
-    .package = "httr2",
-    resp_body_json = function(...) {
-      list(details = "Available year: 2024")
-    }
-  )
+  local_mocked_bindings(gisco_perform_request = function(...) {
+    structure(list(), class = "mock_response")
+  })
+  local_mocked_bindings(gisco_resp_body_json = function(...) {
+    list(details = "Available year: 2024")
+  })
 
   expect_identical(docs_id_years("nuts"), 'is \\code{"2024"}')
 })

--- a/tests/testthat/test-gisco-address-api.R
+++ b/tests/testthat/test-gisco-address-api.R
@@ -1,4 +1,4 @@
-test_that("Test offline", {
+test_that("Address API returns NULL when offline", {
   skip_on_cran()
   skip_if_gisco_offline()
   local_mocked_bindings(is_online_fun = function(...) {
@@ -7,13 +7,9 @@ test_that("Test offline", {
 
   expect_snapshot(fend <- gisco_address_api_bbox())
   expect_null(fend)
-
-  local_mocked_bindings(is_online_fun = function(...) {
-    httr2::is_online()
-  })
 })
 
-test_that("Test 404", {
+test_that("Address API returns NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -51,10 +47,6 @@ test_that("Test 404", {
 
   expect_message(n <- gisco_address_api_copyright(), "Error")
   expect_null(n)
-
-  local_mocked_bindings(is_404 = function(...) {
-    FALSE
-  })
 })
 
 test_that("gisco_address_api_bbox online", {

--- a/tests/testthat/test-gisco-attributions.R
+++ b/tests/testthat/test-gisco-attributions.R
@@ -1,5 +1,6 @@
-test_that("Testing attributions", {
+test_that("Attribution text is exposed as package data", {
   skip_on_cran()
+  skip_if_gisco_offline()
 
   expect_silent(gisco_attributions())
   expect_identical(class(gisco_attributions()), "character")

--- a/tests/testthat/test-gisco-bulk-download.R
+++ b/tests/testthat/test-gisco-bulk-download.R
@@ -1,4 +1,4 @@
-test_that("Test offline", {
+test_that("Bulk download returns NULL when offline", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -7,13 +7,9 @@ test_that("Test offline", {
   })
   expect_message(n <- gisco_bulk_download(update_cache = TRUE), "No internet")
   expect_null(n)
-
-  local_mocked_bindings(is_online_fun = function(...) {
-    httr2::is_online()
-  })
 })
 
-test_that("Test 404", {
+test_that("Bulk download returns NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -22,19 +18,12 @@ test_that("Test 404", {
   })
   expect_message(n <- gisco_bulk_download(update_cache = TRUE), "Error")
   expect_null(n)
-
-  local_mocked_bindings(is_404 = function(...) {
-    FALSE
-  })
 })
 
-test_that("Deprecations", {
+test_that("Bulk download reports deprecated arguments", {
   skip_on_cran()
   skip_if_gisco_offline()
-  cdir <- file.path(tempdir(), "testthat", "bulk")
-  if (dir.exists(cdir)) {
-    unlink(cdir, force = TRUE, recursive = TRUE)
-  }
+  cdir <- local_test_cache_dir("bulk-")
 
   expect_snapshot(
     s <- gisco_bulk_download(
@@ -60,9 +49,6 @@ test_that("Deprecations", {
     recursive = TRUE,
     cache_dir = cdir
   ))
-  if (dir.exists(cdir)) {
-    unlink(cdir, force = TRUE, recursive = TRUE)
-  }
 })
 
 test_that("Bulk download helpers build names and routes", {
@@ -96,8 +82,7 @@ test_that("Bulk download helpers build names and routes", {
 })
 
 test_that("Bulk download orchestrates download and extraction", {
-  cdir <- file.path(tempdir(), "testthat", "bulk-mock")
-  unlink(cdir, force = TRUE, recursive = TRUE)
+  cdir <- local_test_cache_dir("bulk-mock-")
 
   local_mocked_bindings(
     get_url_db = function(...) {
@@ -122,10 +107,7 @@ test_that("Bulk download orchestrates download and extraction", {
     },
     list_bulk_zip_files = function(zipfile) {
       expect_match(zipfile, "ref-countries-2024-60m.geojson.zip$")
-      data.frame(
-        Name = c("country.geojson", "country.txt"),
-        Length = c(1, 1)
-      )
+      data.frame(Name = c("country.geojson", "country.txt"), Length = c(1, 1))
     },
     extract_bulk_zip_files = function(zipfile, files, exdir) {
       expect_identical(files, "country.geojson")
@@ -145,32 +127,27 @@ test_that("Bulk download orchestrates download and extraction", {
   expect_true(file.exists(out))
 })
 
-test_that("Errors", {
+test_that("Bulk download validates user inputs", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  expect_error(gisco_bulk_download(year = "2000"))
-  expect_error(gisco_bulk_download(resolution = "35"))
+  expect_error(gisco_bulk_download(year = "2000"), "Years available")
+  expect_error(gisco_bulk_download(resolution = "35"), "No results")
   expect_snapshot(gisco_bulk_download(id_giscoR = "nutes"), error = TRUE)
-  expect_error(gisco_bulk_download(ext = "aa"))
+  expect_error(gisco_bulk_download(ext = "aa"), "`ext` must be")
 })
 
-test_that("Online mocked", {
+test_that("Bulk download builds recursive downloads from mocked metadata", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  local_mocked_bindings(
-    download_url = function(url = url, ...) {
-      url <- basename(url)
-      cli::cli_alert_info("Mocked {.str {url}}.")
-      NULL
-    }
-  )
+  local_mocked_bindings(download_url = function(url = url, ...) {
+    url <- basename(url)
+    cli::cli_alert_info("Mocked {.str {url}}.")
+    NULL
+  })
 
-  cdir <- file.path(tempdir(), "testthat", "bulk")
-  if (dir.exists(cdir)) {
-    unlink(cdir, force = TRUE, recursive = TRUE)
-  }
+  cdir <- local_test_cache_dir("bulk-")
 
   id <- c(
     "countries",
@@ -203,12 +180,7 @@ test_that("Online mocked", {
 
   # Additional and extensions
   expect_message(
-    gisco_bulk_download(
-      "communes",
-      year = 2004,
-      ext = "svg",
-      cache_dir = cdir
-    ),
+    gisco_bulk_download("communes", year = 2004, ext = "svg", cache_dir = cdir),
     "svg.zip"
   )
 

--- a/tests/testthat/test-gisco-cache.R
+++ b/tests/testthat/test-gisco-cache.R
@@ -75,6 +75,22 @@ test_that("Cache configuration is restored after a restart", {
   expect_true(nzchar(Sys.getenv("GISCO_CACHE_DIR")))
 })
 
+test_that("Cache configuration restores a persisted cache path", {
+  config_dir <- withr::local_tempdir("gisco-config-")
+  cache_dir <- withr::local_tempdir("gisco-cache-")
+  writeLines(cache_dir, file.path(config_dir, "gisco_cache_dir"))
+  withr::local_envvar(GISCO_CACHE_DIR = NA_character_)
+  local_mocked_bindings(
+    gisco_user_dir = function(which = "config") config_dir,
+    migrate_cache = function(...) invisible()
+  )
+
+  muted <- detect_cache_dir_muted()
+
+  expect_identical(muted, cache_dir)
+  expect_identical(Sys.getenv("GISCO_CACHE_DIR"), cache_dir)
+})
+
 test_that("Persistent cache config can be installed and overwritten", {
   skip_on_cran()
   skip_if_gisco_offline()

--- a/tests/testthat/test-gisco-cache.R
+++ b/tests/testthat/test-gisco-cache.R
@@ -1,10 +1,12 @@
-test_that("Test cache", {
+test_that("Cache directory can be set and cleared", {
   skip_on_cran()
+  skip_if_gisco_offline()
   # Get current cache dir
-  expect_message(current <- gisco_detect_cache_dir())
+  current <- gisco_detect_cache_dir()
+  expect_true(nzchar(current))
 
   # Set a temp cache dir
-  expect_message(gisco_set_cache_dir(verbose = TRUE))
+  expect_message(gisco_set_cache_dir(verbose = TRUE), "temporary cache")
   testdir <- expect_silent(gisco_set_cache_dir(
     file.path(current, "testthat"),
     verbose = FALSE
@@ -18,27 +20,28 @@ test_that("Test cache", {
   expect_false(dir.exists(testdir))
 
   # Reset just for testing all cases
-  testdir <- file.path(tempdir(), "giscor", "testthat")
-  expect_message(gisco_set_cache_dir(testdir))
+  testdir <- local_test_cache_dir("gisco-cache-test-")
+  expect_message(gisco_set_cache_dir(testdir), "cache directory")
 
   expect_true(dir.exists(testdir))
 
-  expect_message(gisco_clear_cache(config = FALSE, verbose = TRUE))
+  expect_message(gisco_clear_cache(config = FALSE, verbose = TRUE), "Deleted")
 
   # Cache dir should be deleted now
   expect_false(dir.exists(testdir))
 
   # Restore cache
-  expect_message(gisco_set_cache_dir(current, verbose = TRUE))
+  expect_message(
+    gisco_set_cache_dir(current, verbose = TRUE),
+    "cache directory"
+  )
   expect_silent(gisco_set_cache_dir(current, verbose = FALSE))
   expect_equal(current, Sys.getenv("GISCO_CACHE_DIR"))
   expect_true(dir.exists(current))
 
   # Try cleaning
-  new_dir <- file.path(tempdir(), "newtest")
-  dir.create(new_dir, recursive = TRUE)
-  old_dir <- file.path(tempdir(), "oldtest")
-  dir.create(old_dir, recursive = TRUE)
+  new_dir <- local_test_cache_dir("new-cache-config-")
+  old_dir <- local_test_cache_dir("old-cache-config-")
 
   writeLines("a", file.path(new_dir, "gisco_cache_dir"))
   writeLines("b", file.path(old_dir, "gisco_cache_dir"))
@@ -47,24 +50,18 @@ test_that("Test cache", {
   expect_silent(migrate_cache(old_dir, new_dir))
   expect_true(file.exists(file.path(new_dir, "gisco_cache_dir")))
   expect_false(file.exists(file.path(old_dir, "gisco_cache_dir")))
-  unlink(old_dir, recursive = TRUE, force = TRUE)
-  unlink(new_dir, recursive = TRUE, force = TRUE)
 })
 
-test_that("Mock restart", {
+test_that("Cache configuration is restored after a restart", {
   skip_on_cran()
-  config_root <- withr::local_tempdir("gisco-config-")
-  withr::local_envvar(
-    c(
-      GISCO_CACHE_DIR = NA_character_,
-      R_USER_CONFIG_DIR = config_root,
-      XDG_CONFIG_HOME = config_root
-    )
-  )
+  skip_if_gisco_offline()
+  config_dir <- withr::local_tempdir("gisco-config-")
+  withr::local_envvar(GISCO_CACHE_DIR = NA_character_)
+  local_mocked_bindings(gisco_user_dir = function(which = "config") config_dir)
 
   expect_identical(Sys.getenv("GISCO_CACHE_DIR"), "")
   expect_false(file.exists(file.path(
-    tools::R_user_dir("giscoR", "config"),
+    gisco_user_dir("config"),
     "gisco_cache_dir"
   )))
 
@@ -78,20 +75,84 @@ test_that("Mock restart", {
   expect_true(nzchar(Sys.getenv("GISCO_CACHE_DIR")))
 })
 
-test_that("Mock migration", {
+test_that("Persistent cache config can be installed and overwritten", {
   skip_on_cran()
-  config_root <- withr::local_tempdir("gisco-config-")
-  cache_dir <- withr::local_tempdir("gisco-cache-")
-  old <- withr::local_tempdir("gisco-old-config-")
-  withr::local_envvar(
-    c(
-      GISCO_CACHE_DIR = NA_character_,
-      R_USER_CONFIG_DIR = config_root,
-      XDG_CONFIG_HOME = config_root
-    )
+  skip_if_gisco_offline()
+  root <- withr::local_tempdir("gisco-cache-install-")
+  config_dir <- file.path(root, "config")
+  cache_dir <- file.path(root, "cache")
+  cache_dir2 <- file.path(root, "cache2")
+  withr::local_envvar(GISCO_CACHE_DIR = NA_character_)
+  local_mocked_bindings(gisco_user_dir = function(which = "config") config_dir)
+
+  expect_silent(gisco_set_cache_dir(cache_dir, install = TRUE, verbose = FALSE))
+  giscor_file <- file.path(config_dir, "gisco_cache_dir")
+  expect_true(dir.exists(config_dir))
+  expect_identical(readLines(giscor_file), cache_dir)
+
+  expect_error(
+    gisco_set_cache_dir(cache_dir2, install = TRUE, verbose = FALSE),
+    "already exists"
   )
 
-  new <- tools::R_user_dir("giscoR", "config")
+  expect_silent(gisco_set_cache_dir(
+    cache_dir2,
+    install = TRUE,
+    overwrite = TRUE,
+    verbose = FALSE
+  ))
+  expect_identical(readLines(giscor_file), cache_dir2)
+})
+
+test_that("Clear cache can remove config without cached data", {
+  skip_on_cran()
+  skip_if_gisco_offline()
+  config_dir <- withr::local_tempdir("gisco-config-")
+  cache_dir <- withr::local_tempdir("gisco-cache-")
+  writeLines("cache", file.path(config_dir, "gisco_cache_dir"))
+  writeLines("data", file.path(cache_dir, "data.txt"))
+  withr::local_envvar(GISCO_CACHE_DIR = cache_dir)
+  local_mocked_bindings(
+    gisco_user_dir = function(which = "config") config_dir,
+    migrate_cache = function(...) invisible()
+  )
+
+  expect_message(
+    gisco_clear_cache(config = TRUE, cached_data = FALSE, verbose = TRUE),
+    "Deleted"
+  )
+  expect_false(dir.exists(config_dir))
+  expect_true(dir.exists(cache_dir))
+  expect_false(nzchar(Sys.getenv("GISCO_CACHE_DIR")))
+})
+
+test_that("Empty cache config falls back to temporary cache", {
+  skip_on_cran()
+  skip_if_gisco_offline()
+  config_dir <- withr::local_tempdir("gisco-config-")
+  writeLines("", file.path(config_dir, "gisco_cache_dir"))
+  withr::local_envvar(GISCO_CACHE_DIR = NA_character_)
+  local_mocked_bindings(
+    gisco_user_dir = function(which = "config") config_dir,
+    migrate_cache = function(...) invisible()
+  )
+
+  muted <- detect_cache_dir_muted()
+
+  expect_identical(file.path(tempdir(), "giscoR"), muted)
+  expect_identical(Sys.getenv("GISCO_CACHE_DIR"), muted)
+})
+
+test_that("Legacy cache configuration migrates to the current location", {
+  skip_on_cran()
+  skip_if_gisco_offline()
+  config_dir <- withr::local_tempdir("gisco-config-")
+  cache_dir <- withr::local_tempdir("gisco-cache-")
+  old <- withr::local_tempdir("gisco-old-config-")
+  withr::local_envvar(GISCO_CACHE_DIR = NA_character_)
+  local_mocked_bindings(gisco_user_dir = function(which = "config") config_dir)
+
+  new <- gisco_user_dir("config")
   fname <- "gisco_cache_dir"
   old_fname <- file.path(old, fname)
   new_fname <- file.path(new, fname)

--- a/tests/testthat/test-gisco-check-access.R
+++ b/tests/testthat/test-gisco-check-access.R
@@ -1,4 +1,4 @@
-test_that("Access", {
+test_that("Access checks report GISCO availability", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -11,17 +11,17 @@ test_that("Access", {
   expect_false(gisco_check_access())
 })
 
-test_that("On CRAN", {
+test_that("CRAN environment is detected from NOT_CRAN", {
   skip_on_cran()
   skip_if_gisco_offline()
 
   # Automatically restored when the test exits
-  withr::local_envvar(c(NOT_CRAN = "false"))
+  withr::local_envvar(NOT_CRAN = "false")
 
   expect_true(on_cran())
   expect_false(gisco_check_access())
 
-  withr::local_envvar(c(NOT_CRAN = ""))
+  withr::local_envvar(NOT_CRAN = "")
 
   expect_identical(!interactive(), on_cran())
 })

--- a/tests/testthat/test-gisco-get-airports.R
+++ b/tests/testthat/test-gisco-get-airports.R
@@ -1,4 +1,4 @@
-test_that("Offline", {
+test_that("Airports return NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -7,30 +7,26 @@ test_that("Offline", {
   })
   expect_message(n <- gisco_get_airports(update_cache = TRUE), "Error")
   expect_null(n)
-
-  local_mocked_bindings(is_404 = function(...) {
-    FALSE
-  })
 })
 
 test_that("Airports use the legacy geodata reader", {
-  local_mocked_bindings(
-    read_gisco_dataset = function(url,
-                                  cache_dir = NULL,
-                                  subdir,
-                                  update_cache = FALSE,
-                                  verbose = FALSE,
-                                  post_process = NULL,
-                                  ...) {
-      expect_match(url, "Airports-2013-SHP[.]zip$")
-      expect_identical(cache_dir, "cache")
-      expect_identical(subdir, "airports")
-      expect_true(update_cache)
-      expect_true(verbose)
-      expect_identical(post_process, transform_to_wgs84)
-      data.frame(CNTR_CODE = c("ES", "FR"), name = c("a", "b"))
-    }
-  )
+  local_mocked_bindings(read_gisco_dataset = function(
+    url,
+    cache_dir = NULL,
+    subdir,
+    update_cache = FALSE,
+    verbose = FALSE,
+    post_process = NULL,
+    ...
+  ) {
+    expect_match(url, "Airports-2013-SHP[.]zip$")
+    expect_identical(cache_dir, "cache")
+    expect_identical(subdir, "airports")
+    expect_true(update_cache)
+    expect_true(verbose)
+    expect_identical(post_process, transform_to_wgs84)
+    data.frame(CNTR_CODE = c("ES", "FR"), name = c("a", "b"))
+  })
 
   airports <- gisco_get_airports(
     country = "ES",
@@ -43,19 +39,17 @@ test_that("Airports use the legacy geodata reader", {
 })
 
 test_that("Airports select the 2006 file", {
-  local_mocked_bindings(
-    read_gisco_dataset = function(url, ...) {
-      expect_match(url, "AIRP_SH[.]zip$")
-      data.frame(CNTR_CODE = "ES", name = "a")
-    }
-  )
+  local_mocked_bindings(read_gisco_dataset = function(url, ...) {
+    expect_match(url, "AIRP_SH[.]zip$")
+    data.frame(CNTR_CODE = "ES", name = "a")
+  })
 
   airports <- gisco_get_airports(year = 2006)
   expect_identical(airports$CNTR_CODE, "ES")
 })
 
-test_that("Get airports", {
-  expect_error(gisco_get_airports(year = 2020))
+test_that("Airports download current and legacy point data", {
+  expect_error(gisco_get_airports(year = 2020), "`year` must be")
 
   skip_on_cran()
   skip_if_gisco_offline()

--- a/tests/testthat/test-gisco-get-cached-db.R
+++ b/tests/testthat/test-gisco-get-cached-db.R
@@ -1,4 +1,4 @@
-test_that("Test offline", {
+test_that("Cached database returns NULL when offline", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -10,13 +10,9 @@ test_that("Test offline", {
 
   expect_snapshot(fend <- gisco_get_cached_db(update_cache = TRUE))
   expect_null(fend)
-
-  local_mocked_bindings(is_online_fun = function(...) {
-    httr2::is_online()
-  })
 })
 
-test_that("Test 404", {
+test_that("Cached database returns NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -28,22 +24,18 @@ test_that("Test 404", {
     "Could not access"
   )
   expect_null(n)
-
-  local_mocked_bindings(is_404 = function(...) {
-    FALSE
-  })
 })
 
-test_that("Offline detection", {
+test_that("Cached database stores fallback data when remote access fails", {
   skip_on_cran()
   skip_if_gisco_offline()
+  cdir <- local_test_cache_dir("cache-db-offline-")
+  withr::local_envvar(GISCO_CACHE_DIR = cdir)
+
   cdir <- detect_cache_dir_muted()
   cdir_db <- create_cache_dir(file.path(cdir, "cache_db"))
 
   cached_db <- file.path(cdir_db, "gisco_cached_db.rds")
-  if (file.exists(cached_db)) {
-    unlink(cached_db)
-  }
   expect_false(file.exists(cached_db))
   local_mocked_bindings(is_404 = function(...) {
     TRUE
@@ -55,20 +47,13 @@ test_that("Offline detection", {
   # Next time silent and cached
   expect_silent(n2 <- get_db())
   expect_identical(n2, gisco_db)
-
-  if (file.exists(cached_db)) {
-    unlink(cached_db)
-  }
-  expect_false(file.exists(cached_db))
-  local_mocked_bindings(is_404 = function(...) {
-    FALSE
-  })
 })
-test_that("On CRAN", {
+test_that("Cached database is still created under CRAN settings", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  withr::local_envvar(c(NOT_CRAN = "false"))
+  cdir <- local_test_cache_dir("cache-db-cran-")
+  withr::local_envvar(GISCO_CACHE_DIR = cdir, NOT_CRAN = "false")
 
   expect_true(on_cran())
 
@@ -76,9 +61,6 @@ test_that("On CRAN", {
   cdir_db <- create_cache_dir(file.path(cdir, "cache_db"))
   cached_db <- file.path(cdir_db, "gisco_cached_db.rds")
 
-  withr::defer(unlink(cached_db))
-
-  unlink(cached_db)
   expect_false(file.exists(cached_db))
 
   expect_silent(n <- gisco_get_cached_db())
@@ -86,8 +68,7 @@ test_that("On CRAN", {
   expect_true(file.exists(cached_db))
 })
 test_that("Cached DB helpers build cache paths and scrape entries", {
-  cdir <- file.path(tempdir(), "testthat", "cache-db-helper")
-  unlink(cdir, force = TRUE, recursive = TRUE)
+  cdir <- local_test_cache_dir("cache-db-helper-")
 
   expect_identical(
     cached_db_file(cdir),
@@ -95,11 +76,9 @@ test_that("Cached DB helpers build cache paths and scrape entries", {
   )
   expect_true(dir.exists(file.path(cdir, "cache_db")))
 
-  local_mocked_bindings(
-    scrap_api_data = function(entry_point) {
-      data.frame(id_giscor = entry_point, year = "2024")
-    }
-  )
+  local_mocked_bindings(scrap_api_data = function(entry_point) {
+    data.frame(id_giscor = entry_point, year = "2024")
+  })
   db <- scrape_distribution_db(c("nuts", "lau"))
   expect_identical(db$id_giscor, c("nuts", "lau"))
 })
@@ -138,7 +117,7 @@ test_that("Cached DB normalization adds derived columns", {
   expect_true("CITIES" %in% out$level)
 })
 
-test_that("Get database", {
+test_that("Cached database refreshes from the remote metadata", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -155,14 +134,16 @@ test_that("Get database", {
   expect_snapshot(sort(unique(new_db$year)))
 })
 
-test_that("Test cached database", {
+test_that("Cached database reuses the local RDS file", {
   skip_on_cran()
   skip_if_gisco_offline()
+  cdir <- local_test_cache_dir("cache-db-")
+  withr::local_envvar(GISCO_CACHE_DIR = cdir)
+
   cdir <- detect_cache_dir_muted()
   cdir_db <- create_cache_dir(file.path(cdir, "cache_db"))
 
   cached_db <- file.path(cdir_db, "gisco_cached_db.rds")
-  unlink(cached_db)
   expect_false(file.exists(cached_db))
 
   # Get db

--- a/tests/testthat/test-gisco-get-census.R
+++ b/tests/testthat/test-gisco-get-census.R
@@ -1,4 +1,4 @@
-test_that("Offline", {
+test_that("Census returns NULL for 404 responses", {
   local_mocked_bindings(
     is_404 = function(...) {
       TRUE
@@ -16,23 +16,23 @@ test_that("Offline", {
 })
 
 test_that("Census uses the legacy geodata reader", {
-  local_mocked_bindings(
-    read_gisco_dataset = function(url,
-                                  cache_dir = NULL,
-                                  subdir,
-                                  update_cache = FALSE,
-                                  verbose = FALSE,
-                                  post_process = NULL,
-                                  ...) {
-      expect_match(url, "CENSUS_UNITS_2011_RG_SH[.]zip$")
-      expect_identical(cache_dir, "cache")
-      expect_identical(subdir, "census")
-      expect_true(update_cache)
-      expect_true(verbose)
-      expect_identical(post_process, transform_to_wgs84)
-      data.frame(id = "RG")
-    }
-  )
+  local_mocked_bindings(read_gisco_dataset = function(
+    url,
+    cache_dir = NULL,
+    subdir,
+    update_cache = FALSE,
+    verbose = FALSE,
+    post_process = NULL,
+    ...
+  ) {
+    expect_match(url, "CENSUS_UNITS_2011_RG_SH[.]zip$")
+    expect_identical(cache_dir, "cache")
+    expect_identical(subdir, "census")
+    expect_true(update_cache)
+    expect_true(verbose)
+    expect_identical(post_process, transform_to_wgs84)
+    data.frame(id = "RG")
+  })
 
   census <- gisco_get_census(
     cache_dir = "cache",
@@ -43,30 +43,30 @@ test_that("Census uses the legacy geodata reader", {
 })
 
 test_that("Census selects the point file", {
-  local_mocked_bindings(
-    read_gisco_dataset = function(url, ...) {
-      expect_match(url, "CENSUS_UNITS_PT_2011_SH[.]zip$")
-      data.frame(id = "PT")
-    }
-  )
+  local_mocked_bindings(read_gisco_dataset = function(url, ...) {
+    expect_match(url, "CENSUS_UNITS_PT_2011_SH[.]zip$")
+    data.frame(id = "PT")
+  })
 
   census <- gisco_get_census(spatialtype = "PT")
   expect_identical(census$id, "PT")
 })
 
-test_that("Get Census POINT", {
-  expect_error(gisco_get_census(year = 2020))
+test_that("Census reads point geometries", {
+  expect_error(gisco_get_census(year = 2020), "`year` must be")
 
-  local_mocked_bindings(
-    read_gisco_dataset = function(url, post_process = NULL, ...) {
-      expect_match(url, "CENSUS_UNITS_PT_2011_SH[.]zip$")
-      data <- sf::st_as_sf(tibble::tibble(
-        id = "PT",
-        geometry = sf::st_sfc(sf::st_point(c(1, 1)), crs = 4326)
-      ))
-      post_process(data)
-    }
-  )
+  local_mocked_bindings(read_gisco_dataset = function(
+    url,
+    post_process = NULL,
+    ...
+  ) {
+    expect_match(url, "CENSUS_UNITS_PT_2011_SH[.]zip$")
+    data <- sf::st_as_sf(tibble::tibble(
+      id = "PT",
+      geometry = sf::st_sfc(sf::st_point(c(1, 1)), crs = 4326)
+    ))
+    post_process(data)
+  })
 
   all <- expect_silent(gisco_get_census(spatialtype = "PT"))
   expect_s3_class(all, "tbl_df")
@@ -74,33 +74,36 @@ test_that("Get Census POINT", {
   expect_true(unique(sf::st_geometry_type(all)) == "POINT")
   expect_identical(sf::st_crs(all), sf::st_crs(4326))
 })
-test_that("Get Census POLYGON", {
-  local_mocked_bindings(
-    read_gisco_dataset = function(url,
-                                  post_process = NULL,
-                                  verbose = FALSE,
-                                  ...) {
-      expect_match(url, "CENSUS_UNITS_2011_RG_SH[.]zip$")
-      expect_false(verbose)
-      data <- sf::st_as_sf(tibble::tibble(
-        id = "RG",
-        geometry = sf::st_sfc(
-          sf::st_multipolygon(list(list(rbind(
-            c(0, 0),
-            c(1, 0),
-            c(1, 1),
-            c(0, 0)
-          )))),
-          crs = 4326
-        )
-      ))
-      message("Mocked census polygon read.")
-      post_process(data)
-    }
-  )
+test_that("Census reads polygon geometries", {
+  local_mocked_bindings(read_gisco_dataset = function(
+    url,
+    post_process = NULL,
+    verbose = FALSE,
+    ...
+  ) {
+    expect_match(url, "CENSUS_UNITS_2011_RG_SH[.]zip$")
+    expect_false(verbose)
+    data <- sf::st_as_sf(tibble::tibble(
+      id = "RG",
+      geometry = sf::st_sfc(
+        sf::st_multipolygon(list(list(rbind(
+          c(0, 0),
+          c(1, 0),
+          c(1, 1),
+          c(0, 0)
+        )))),
+        crs = 4326
+      )
+    ))
+    message("Mocked census polygon read.")
+    post_process(data)
+  })
 
   # On read should warn
-  expect_message(all <- gisco_get_census(spatialtype = "RG"))
+  expect_message(
+    all <- gisco_get_census(spatialtype = "RG"),
+    "Mocked census polygon read"
+  )
   expect_s3_class(all, "tbl_df")
   expect_s3_class(all, "sf")
   expect_true(unique(sf::st_geometry_type(all)) == "MULTIPOLYGON")

--- a/tests/testthat/test-gisco-get-coastal-lines.R
+++ b/tests/testthat/test-gisco-get-coastal-lines.R
@@ -1,4 +1,4 @@
-test_that("Offline", {
+test_that("Coastal lines return NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -10,9 +10,6 @@ test_that("Offline", {
     "Error"
   )
   expect_null(n)
-  local_mocked_bindings(is_404 = function(...) {
-    FALSE
-  })
 })
 
 test_that("Coastal lines use resolved GISCO files", {
@@ -52,21 +49,18 @@ test_that("Coastal lines use resolved GISCO files", {
   expect_identical(coast$id, 1)
 })
 
-test_that("Errors", {
+test_that("Coastal lines validate unsupported extensions", {
   skip_on_cran()
   skip_if_gisco_offline()
 
   expect_snapshot(gisco_get_coastal_lines(ext = "docx"), error = TRUE)
 })
 
-test_that("Cached dataset vs updated", {
+test_that("Coastal lines can refresh an existing cached dataset", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "testcoast")
-  if (dir.exists(cdir)) {
-    unlink(cdir, recursive = TRUE, force = TRUE)
-  }
+  cdir <- local_test_cache_dir("testcoast-")
 
   expect_identical(list.files(cdir, recursive = TRUE), character(0))
   expect_snapshot(db_cached <- gisco_get_coastal_lines(verbose = TRUE))
@@ -82,19 +76,13 @@ test_that("Cached dataset vs updated", {
     list.files(cdir, recursive = TRUE),
     "coastal/COAS_RG_20M_2016_4326.gpkg"
   )
-
-  # Cleanup
-  unlink(cdir, recursive = TRUE, force = TRUE)
 })
 
-test_that("Cache vs non-cached", {
+test_that("Coastal lines return matching data with and without cache", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "testcoast")
-  if (dir.exists(cdir)) {
-    unlink(cdir, recursive = TRUE, force = TRUE)
-  }
+  cdir <- local_test_cache_dir("testcoast-")
 
   expect_identical(list.files(cdir, recursive = TRUE), character(0))
   expect_message(
@@ -136,19 +124,13 @@ test_that("Cache vs non-cached", {
     cache = FALSE
   )
   expect_length(list.files(cdir, recursive = TRUE, pattern = "shp"), 1)
-
-  # Cleanup
-  unlink(cdir, recursive = TRUE, force = TRUE)
 })
 
-test_that("Extensions", {
+test_that("Coastal lines support GeoJSON and zipped shapefile downloads", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "testcoast")
-  if (dir.exists(cdir)) {
-    unlink(cdir, recursive = TRUE, force = TRUE)
-  }
+  cdir <- local_test_cache_dir("testcoast-")
 
   expect_identical(list.files(cdir, recursive = TRUE), character(0))
 
@@ -173,12 +155,9 @@ test_that("Extensions", {
   expect_s3_class(db_zip, "tbl_df")
 
   expect_length(list.files(cdir, recursive = TRUE, pattern = "shp.zip"), 1)
-
-  # Cleanup
-  unlink(cdir, recursive = TRUE, force = TRUE)
 })
 
-test_that("Coastal online", {
+test_that("Coastal lines keep deprecated alias behavior online", {
   skip_on_cran()
   skip_if_gisco_offline()
 

--- a/tests/testthat/test-gisco-get-communes.R
+++ b/tests/testthat/test-gisco-get-communes.R
@@ -1,4 +1,4 @@
-test_that("offline", {
+test_that("Communes return NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -10,10 +10,6 @@ test_that("offline", {
     "Error"
   )
   expect_null(n)
-
-  local_mocked_bindings(is_404 = function(...) {
-    FALSE
-  })
 })
 
 test_that("Communes use resolved GISCO files", {
@@ -54,15 +50,21 @@ test_that("Communes use resolved GISCO files", {
   expect_identical(communes$CNTR_CODE, c("ES", "FR"))
 })
 
-test_that("Communes errors", {
+test_that("Communes validate year, EPSG and spatial type", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  expect_error(gisco_get_communes(year = "2007"))
-  expect_error(gisco_get_communes(epsg = "9999"))
-  expect_error(gisco_get_communes(year = "2004", spatialtype = "COASTL"))
-  expect_error(gisco_get_communes(year = "2004", spatialtype = "INLAND"))
-  expect_error(gisco_get_communes(spatialtype = "ERR"))
+  expect_error(gisco_get_communes(year = "2007"), "Years available")
+  expect_error(gisco_get_communes(epsg = "9999"), "No results")
+  expect_error(
+    gisco_get_communes(year = "2004", spatialtype = "COASTL"),
+    "No results"
+  )
+  expect_error(
+    gisco_get_communes(year = "2004", spatialtype = "INLAND"),
+    "No results"
+  )
+  expect_error(gisco_get_communes(spatialtype = "ERR"), "No results")
 })
 
 test_that("Communes pass country filters to the reader", {
@@ -112,17 +114,15 @@ test_that("Communes pass country filters to the reader", {
   expect_identical(communes$CNTR_CODE, "LU")
   expect_identical(
     filter_calls,
-    list(
-      list(
-        file_local = "communes.gpkg",
-        values = "LU",
-        candidates = c("CNTR_ID", "CNTR_CODE")
-      )
-    )
+    list(list(
+      file_local = "communes.gpkg",
+      values = "LU",
+      candidates = c("CNTR_ID", "CNTR_CODE")
+    ))
   )
 })
 
-test_that("Deprecations", {
+test_that("Communes report deprecated cache usage", {
   local_mocked_bindings(
     resolve_gisco_file = function(...) {
       list(
@@ -138,7 +138,7 @@ test_that("Deprecations", {
   expect_snapshot(s <- gisco_get_communes(cache = FALSE, spatialtype = "LB"))
 })
 
-test_that("Extensions", {
+test_that("Communes reject unsupported extensions and read GeoJSON", {
   skip_on_cran()
   skip_if_gisco_offline()
 

--- a/tests/testthat/test-gisco-get-countries.R
+++ b/tests/testthat/test-gisco-get-countries.R
@@ -1,4 +1,4 @@
-test_that("Offline", {
+test_that("Countries return NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -10,9 +10,6 @@ test_that("Offline", {
     "Error"
   )
   expect_null(n)
-  local_mocked_bindings(is_404 = function(...) {
-    FALSE
-  })
 })
 
 test_that("Countries use resolved GISCO files", {
@@ -58,14 +55,11 @@ test_that("Countries use resolved GISCO files", {
   expect_identical(countries$CNTR_ID, "ES")
 })
 
-test_that("Cached dataset vs updated", {
+test_that("Countries can refresh an existing cached dataset", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "testcountry")
-  if (dir.exists(cdir)) {
-    unlink(cdir, recursive = TRUE, force = TRUE)
-  }
+  cdir <- local_test_cache_dir("testcountry-")
 
   expect_identical(list.files(cdir, recursive = TRUE), character(0))
   expect_snapshot(db_cached <- gisco_get_countries(verbose = TRUE))
@@ -81,19 +75,13 @@ test_that("Cached dataset vs updated", {
     list.files(cdir, recursive = TRUE),
     "countries/CNTR_RG_20M_2024_4326.gpkg"
   )
-
-  # Cleanup
-  unlink(cdir, recursive = TRUE, force = TRUE)
 })
 
-test_that("Cache vs non-cached", {
+test_that("Countries return matching data with and without cache", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "testcountry")
-  if (dir.exists(cdir)) {
-    unlink(cdir, recursive = TRUE, force = TRUE)
-  }
+  cdir <- local_test_cache_dir("testcountry-")
 
   expect_identical(list.files(cdir, recursive = TRUE), character(0))
   expect_message(
@@ -135,11 +123,8 @@ test_that("Cache vs non-cached", {
     cache = FALSE
   )
   expect_length(list.files(cdir, recursive = TRUE, pattern = "shp"), 1)
-
-  # Cleanup
-  unlink(cdir, recursive = TRUE, force = TRUE)
 })
-test_that("Filter countries", {
+test_that("Countries can be filtered by region or country", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -184,7 +169,7 @@ test_that("Filter countries", {
   )
 })
 
-test_that("Filter countries no cached", {
+test_that("Countries filters also work without cache", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -242,7 +227,7 @@ test_that("Filter countries no cached", {
   expect_identical(nrow(bn), nrow(bn_nocach))
 })
 
-test_that("Spatial types", {
+test_that("Countries support boundary, label and coastline spatial types", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -291,17 +276,14 @@ test_that("Spatial types", {
   )
 })
 
-test_that("Extensions", {
+test_that("Countries support GeoJSON and zipped shapefile downloads", {
   skip_on_cran()
   skip_if_gisco_offline()
 
   # Error
   expect_snapshot(gisco_get_countries(ext = "docx"), error = TRUE)
 
-  cdir <- file.path(tempdir(), "testcountry")
-  if (dir.exists(cdir)) {
-    unlink(cdir, recursive = TRUE, force = TRUE)
-  }
+  cdir <- local_test_cache_dir("testcountry-")
 
   expect_identical(list.files(cdir, recursive = TRUE), character(0))
 
@@ -326,7 +308,4 @@ test_that("Extensions", {
   expect_s3_class(db_zip, "tbl_df")
 
   expect_length(list.files(cdir, recursive = TRUE, pattern = "shp.zip"), 1)
-
-  # Cleanup
-  unlink(cdir, recursive = TRUE, force = TRUE)
 })

--- a/tests/testthat/test-gisco-get-education.R
+++ b/tests/testthat/test-gisco-get-education.R
@@ -1,4 +1,4 @@
-test_that("Offline", {
+test_that("Education returns NULL for 404 responses", {
   local_mocked_bindings(
     is_404 = function(...) {
       TRUE
@@ -17,25 +17,25 @@ test_that("Offline", {
 
 test_that("Education uses basic service URLs", {
   urls <- character()
-  local_mocked_bindings(
-    read_gisco_dataset = function(url,
-                                  name,
-                                  cache = TRUE,
-                                  cache_dir = NULL,
-                                  subdir,
-                                  update_cache = FALSE,
-                                  verbose = FALSE,
-                                  ...) {
-      urls <<- c(urls, url)
-      expect_match(name, "^edu_2023_")
-      expect_false(cache)
-      expect_identical(cache_dir, "cache")
-      expect_identical(subdir, "education")
-      expect_true(update_cache)
-      expect_true(verbose)
-      data.frame(cntr_id = basename(tools::file_path_sans_ext(url)))
-    }
-  )
+  local_mocked_bindings(read_gisco_dataset = function(
+    url,
+    name,
+    cache = TRUE,
+    cache_dir = NULL,
+    subdir,
+    update_cache = FALSE,
+    verbose = FALSE,
+    ...
+  ) {
+    urls <<- c(urls, url)
+    expect_match(name, "^edu_2023_")
+    expect_false(cache)
+    expect_identical(cache_dir, "cache")
+    expect_identical(subdir, "education")
+    expect_true(update_cache)
+    expect_true(verbose)
+    data.frame(cntr_id = basename(tools::file_path_sans_ext(url)))
+  })
 
   education <- gisco_get_education(
     country = c("LU", "BE"),
@@ -44,19 +44,13 @@ test_that("Education uses basic service URLs", {
     update_cache = TRUE,
     verbose = TRUE
   )
-  expect_identical(
-    urls,
-    basic_service_url("education", "2023", c("LU", "BE"))
-  )
+  expect_identical(urls, basic_service_url("education", "2023", c("LU", "BE")))
   expect_identical(education$cntr_id, c("LU", "BE"))
 })
 
 test_that("Basic service helpers build URLs and file names", {
   url <- basic_service_url("healthcare", "2020")
-  expect_identical(
-    url,
-    paste0(gisco_pub_url(), "healthcare/2020/gpkg/EU.gpkg")
-  )
+  expect_identical(url, paste0(gisco_pub_url(), "healthcare/2020/gpkg/EU.gpkg"))
   expect_identical(
     basic_service_filename("health", "2020", url),
     "health_2020_EU.gpkg"
@@ -64,37 +58,34 @@ test_that("Basic service helpers build URLs and file names", {
 })
 
 test_that("Education reads mocked 2023 service data", {
-  local_mocked_bindings(
-    read_gisco_dataset = function(url,
-                                  name,
-                                  cache = TRUE,
-                                  cache_dir = NULL,
-                                  subdir,
-                                  verbose = FALSE,
-                                  ...) {
-      expect_identical(subdir, "education")
-      expect_match(name, "^edu_2023_")
-      if (verbose) {
-        message("Mocked education read.")
-      }
-
-      country <- tools::file_path_sans_ext(basename(url))
-      if (identical(country, "EU")) {
-        country <- sprintf("C%02d", seq_len(11))
-      }
-      geometry <- do.call(
-        sf::st_sfc,
-        c(
-          lapply(seq_along(country), function(x) sf::st_point(c(x, x))),
-          crs = 4326
-        )
-      )
-      sf::st_as_sf(tibble::tibble(
-        cntr_id = country,
-        geometry = geometry
-      ))
+  local_mocked_bindings(read_gisco_dataset = function(
+    url,
+    name,
+    cache = TRUE,
+    cache_dir = NULL,
+    subdir,
+    verbose = FALSE,
+    ...
+  ) {
+    expect_identical(subdir, "education")
+    expect_match(name, "^edu_2023_")
+    if (verbose) {
+      message("Mocked education read.")
     }
-  )
+
+    country <- tools::file_path_sans_ext(basename(url))
+    if (identical(country, "EU")) {
+      country <- sprintf("C%02d", seq_len(11))
+    }
+    geometry <- do.call(
+      sf::st_sfc,
+      c(
+        lapply(seq_along(country), function(x) sf::st_point(c(x, x))),
+        crs = 4326
+      )
+    )
+    sf::st_as_sf(tibble::tibble(cntr_id = country, geometry = geometry))
+  })
 
   expect_silent(gisco_get_education(country = "LU", cache = FALSE))
   expect_silent(gisco_get_education(country = "Denmark"))
@@ -116,21 +107,25 @@ test_that("Education reads mocked 2023 service data", {
 })
 
 test_that("Education reads mocked 2020 service data", {
-  local_mocked_bindings(
-    read_gisco_dataset = function(url, name, subdir, verbose = FALSE, ...) {
-      expect_identical(subdir, "education")
-      expect_match(name, "^edu_2020_")
-      if (verbose) {
-        message("Mocked education 2020 read.")
-      }
-
-      country <- tools::file_path_sans_ext(basename(url))
-      sf::st_as_sf(tibble::tibble(
-        cntr_id = country,
-        geometry = sf::st_sfc(sf::st_point(c(1, 1)), crs = 4326)
-      ))
+  local_mocked_bindings(read_gisco_dataset = function(
+    url,
+    name,
+    subdir,
+    verbose = FALSE,
+    ...
+  ) {
+    expect_identical(subdir, "education")
+    expect_match(name, "^edu_2020_")
+    if (verbose) {
+      message("Mocked education 2020 read.")
     }
-  )
+
+    country <- tools::file_path_sans_ext(basename(url))
+    sf::st_as_sf(tibble::tibble(
+      cntr_id = country,
+      geometry = sf::st_sfc(sf::st_point(c(1, 1)), crs = 4326)
+    ))
+  })
 
   expect_silent(gisco_get_education(country = "LU", cache = FALSE, year = 2020))
   expect_silent(gisco_get_education(country = "Denmark", year = 2020))

--- a/tests/testthat/test-gisco-get-grid.R
+++ b/tests/testthat/test-gisco-get-grid.R
@@ -1,26 +1,26 @@
 test_that("Grid validates inputs", {
-  expect_error(gisco_get_grid(resolution = 24))
-  expect_error(gisco_get_grid(spatialtype = "9999"))
+  expect_error(gisco_get_grid(resolution = 24), "`resolution` must be")
+  expect_error(gisco_get_grid(spatialtype = "9999"), "`spatialtype` must be")
 })
 
 test_that("Grids use the grid dataset reader", {
-  local_mocked_bindings(
-    read_gisco_dataset = function(url,
-                                  name,
-                                  cache_dir = NULL,
-                                  subdir,
-                                  update_cache = FALSE,
-                                  verbose = FALSE,
-                                  ...) {
-      expect_match(url, "grid_100km_surf[.]gpkg$")
-      expect_identical(name, "grid_100km_surf.gpkg")
-      expect_identical(cache_dir, "cache")
-      expect_identical(subdir, "grid")
-      expect_true(update_cache)
-      expect_true(verbose)
-      data.frame(id = "grid")
-    }
-  )
+  local_mocked_bindings(read_gisco_dataset = function(
+    url,
+    name,
+    cache_dir = NULL,
+    subdir,
+    update_cache = FALSE,
+    verbose = FALSE,
+    ...
+  ) {
+    expect_match(url, "grid_100km_surf[.]gpkg$")
+    expect_identical(name, "grid_100km_surf.gpkg")
+    expect_identical(cache_dir, "cache")
+    expect_identical(subdir, "grid")
+    expect_true(update_cache)
+    expect_true(verbose)
+    data.frame(id = "grid")
+  })
 
   grid <- gisco_get_grid(
     100,
@@ -32,19 +32,17 @@ test_that("Grids use the grid dataset reader", {
 })
 
 test_that("Grids select point files", {
-  local_mocked_bindings(
-    read_gisco_dataset = function(url, name, ...) {
-      expect_match(url, "grid_100km_point[.]gpkg$")
-      expect_identical(name, "grid_100km_point.gpkg")
-      data.frame(id = "point")
-    }
-  )
+  local_mocked_bindings(read_gisco_dataset = function(url, name, ...) {
+    expect_match(url, "grid_100km_point[.]gpkg$")
+    expect_identical(name, "grid_100km_point.gpkg")
+    data.frame(id = "point")
+  })
 
   grid <- gisco_get_grid(100, spatialtype = "POINT")
   expect_identical(grid$id, "point")
 })
 
-test_that("Offline", {
+test_that("Grids return NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -53,7 +51,4 @@ test_that("Offline", {
   })
   expect_message(n <- gisco_get_grid(update_cache = TRUE), "Error")
   expect_null(n)
-  local_mocked_bindings(is_404 = function(...) {
-    FALSE
-  })
 })

--- a/tests/testthat/test-gisco-get-healthcare.R
+++ b/tests/testthat/test-gisco-get-healthcare.R
@@ -1,4 +1,4 @@
-test_that("Offline", {
+test_that("Healthcare returns NULL for 404 responses", {
   local_mocked_bindings(
     is_404 = function(...) {
       TRUE
@@ -16,29 +16,29 @@ test_that("Offline", {
 })
 
 test_that("Healthcare uses the basic service dataset", {
-  local_mocked_bindings(
-    read_gisco_dataset = function(url,
-                                  name,
-                                  cache = TRUE,
-                                  cache_dir = NULL,
-                                  subdir,
-                                  update_cache = FALSE,
-                                  verbose = FALSE,
-                                  post_process = NULL,
-                                  ...) {
-      expect_identical(url, basic_service_url("healthcare", "2020"))
-      expect_identical(name, "health_2020_EU.gpkg")
-      expect_false(cache)
-      expect_identical(cache_dir, "cache")
-      expect_identical(subdir, "health")
-      expect_true(update_cache)
-      expect_true(verbose)
-      expect_true(is.function(post_process))
+  local_mocked_bindings(read_gisco_dataset = function(
+    url,
+    name,
+    cache = TRUE,
+    cache_dir = NULL,
+    subdir,
+    update_cache = FALSE,
+    verbose = FALSE,
+    post_process = NULL,
+    ...
+  ) {
+    expect_identical(url, basic_service_url("healthcare", "2020"))
+    expect_identical(name, "health_2020_EU.gpkg")
+    expect_false(cache)
+    expect_identical(cache_dir, "cache")
+    expect_identical(subdir, "health")
+    expect_true(update_cache)
+    expect_true(verbose)
+    expect_true(is.function(post_process))
 
-      data <- data.frame(cntr_id = c("LU", "BE"), name = c("a", "b"))
-      post_process(data)
-    }
-  )
+    data <- data.frame(cntr_id = c("LU", "BE"), name = c("a", "b"))
+    post_process(data)
+  })
 
   healthcare <- gisco_get_healthcare(
     year = 2020,
@@ -52,49 +52,46 @@ test_that("Healthcare uses the basic service dataset", {
 })
 
 test_that("Healthcare reads, filters and caches mocked data", {
-  cdir <- file.path(tempdir(), "test_health")
-  unlink(cdir, force = TRUE, recursive = TRUE)
-  expect_false(dir.exists(cdir))
-  create_cache_dir(cdir)
+  cdir <- local_test_cache_dir("test-health-")
   expect_true(dir.exists(cdir))
 
-  local_mocked_bindings(
-    read_gisco_dataset = function(url,
-                                  name,
-                                  cache = TRUE,
-                                  cache_dir = NULL,
-                                  subdir,
-                                  verbose = FALSE,
-                                  post_process = NULL,
-                                  ...) {
-      expect_identical(url, basic_service_url("healthcare", "2023"))
-      expect_identical(name, "health_2023_EU.gpkg")
-      expect_identical(subdir, "health")
-      if (!is.null(cache_dir)) {
-        expect_identical(cache_dir, cdir)
-      }
-
-      if (cache) {
-        create_cache_dir(file.path(cache_dir, subdir))
-        file.create(file.path(cache_dir, subdir, name))
-      }
-      if (verbose) {
-        message("Mocked healthcare read.")
-      }
-
-      data <- sf::st_as_sf(tibble::tibble(
-        cntr_id = c("LU", "ES", "BE", "ES"),
-        geometry = sf::st_sfc(
-          sf::st_point(c(1, 1)),
-          sf::st_point(c(2, 2)),
-          sf::st_point(c(3, 3)),
-          sf::st_point(c(4, 4)),
-          crs = 4326
-        )
-      ))
-      post_process(data)
+  local_mocked_bindings(read_gisco_dataset = function(
+    url,
+    name,
+    cache = TRUE,
+    cache_dir = NULL,
+    subdir,
+    verbose = FALSE,
+    post_process = NULL,
+    ...
+  ) {
+    expect_identical(url, basic_service_url("healthcare", "2023"))
+    expect_identical(name, "health_2023_EU.gpkg")
+    expect_identical(subdir, "health")
+    if (!is.null(cache_dir)) {
+      expect_identical(cache_dir, cdir)
     }
-  )
+
+    if (cache) {
+      create_cache_dir(file.path(cache_dir, subdir))
+      file.create(file.path(cache_dir, subdir, name))
+    }
+    if (verbose) {
+      message("Mocked healthcare read.")
+    }
+
+    data <- sf::st_as_sf(tibble::tibble(
+      cntr_id = c("LU", "ES", "BE", "ES"),
+      geometry = sf::st_sfc(
+        sf::st_point(c(1, 1)),
+        sf::st_point(c(2, 2)),
+        sf::st_point(c(3, 3)),
+        sf::st_point(c(4, 4)),
+        crs = 4326
+      )
+    ))
+    post_process(data)
+  })
 
   # No Cache
   expect_silent(
@@ -122,7 +119,5 @@ test_that("Healthcare reads, filters and caches mocked data", {
   )
   expect_lt(nrow(esp), nrow(n))
 
-  expect_message(gisco_get_healthcare(verbose = TRUE))
-  unlink(cdir, force = TRUE, recursive = TRUE)
-  expect_false(dir.exists(cdir))
+  expect_message(gisco_get_healthcare(verbose = TRUE), "Mocked healthcare read")
 })

--- a/tests/testthat/test-gisco-get-lau.R
+++ b/tests/testthat/test-gisco-get-lau.R
@@ -1,4 +1,4 @@
-test_that("offline", {
+test_that("LAU returns NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -7,10 +7,6 @@ test_that("offline", {
   })
   expect_message(n <- gisco_get_lau(update_cache = TRUE, year = 2020), "Error")
   expect_null(n)
-
-  local_mocked_bindings(is_404 = function(...) {
-    FALSE
-  })
 })
 
 test_that("LAU use resolved GISCO files", {
@@ -53,12 +49,12 @@ test_that("LAU use resolved GISCO files", {
   expect_identical(lau$GISCO_ID, "ES_12016")
 })
 
-test_that("LAU Errors", {
+test_that("LAU validates year and EPSG", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  expect_error(gisco_get_lau(year = "2001"))
-  expect_error(gisco_get_lau(epsg = "9999"))
+  expect_error(gisco_get_lau(year = "2001"), "Years available")
+  expect_error(gisco_get_lau(epsg = "9999"), "No results")
 })
 
 test_that("LAU combines country and GISCO ID filters", {
@@ -100,15 +96,9 @@ test_that("LAU combines country and GISCO ID filters", {
       filter_result <- filters("lau.gpkg")
       expect_identical(
         filter_result,
-        list(
-          "CNTR_ID|CNTR_CODE" = "LI",
-          GISCO_ID = "ES_12016"
-        )
+        list("CNTR_ID|CNTR_CODE" = "LI", GISCO_ID = "ES_12016")
       )
-      data.frame(
-        CNTR_CODE = c("LI", "ES"),
-        GISCO_ID = c("LI_0101", "ES_12016")
-      )
+      data.frame(CNTR_CODE = c("LI", "ES"), GISCO_ID = c("LI_0101", "ES_12016"))
     }
   )
 
@@ -132,7 +122,7 @@ test_that("LAU combines country and GISCO ID filters", {
   )
 })
 
-test_that("Deprecations", {
+test_that("LAU reports deprecated cache usage", {
   local_mocked_bindings(
     resolve_gisco_file = function(...) {
       list(
@@ -152,7 +142,7 @@ test_that("Deprecations", {
   expect_equal(s$GISCO_ID, "ES_12016")
 })
 
-test_that("Extensions", {
+test_that("LAU rejects unsupported extensions and reads GeoJSON", {
   skip_on_cran()
   skip_if_gisco_offline()
 

--- a/tests/testthat/test-gisco-get-metadata.R
+++ b/tests/testthat/test-gisco-get-metadata.R
@@ -1,4 +1,4 @@
-test_that("Test offline", {
+test_that("Metadata returns NULL when offline", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -8,13 +8,9 @@ test_that("Test offline", {
 
   expect_snapshot(fend <- gisco_get_metadata())
   expect_null(fend)
-
-  local_mocked_bindings(is_online_fun = function(...) {
-    httr2::is_online()
-  })
 })
 
-test_that("Test 404", {
+test_that("Metadata returns NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -23,9 +19,6 @@ test_that("Test 404", {
   })
   expect_message(n <- gisco_get_metadata(), "Error")
   expect_null(n)
-  local_mocked_bindings(is_404 = function(...) {
-    FALSE
-  })
 })
 
 test_that("Metadata helpers build URL and read CSV", {
@@ -54,44 +47,44 @@ test_that("Metadata helpers build URL and read CSV", {
 })
 
 test_that("Metadata downloads to the metadata cache", {
-  local_mocked_bindings(
-    download_url = function(url,
-                            name,
-                            cache_dir,
-                            subdir,
-                            verbose = FALSE,
-                            ...) {
-      expect_match(url, "_AT")
-      expect_match(name, "[.]csv$")
-      expect_identical(cache_dir, tempdir())
-      expect_identical(subdir, "gisco_metadata")
-      expect_true(verbose)
+  local_mocked_bindings(download_url = function(
+    url,
+    name,
+    cache_dir,
+    subdir,
+    verbose = FALSE,
+    ...
+  ) {
+    expect_match(url, "_AT")
+    expect_match(name, "[.]csv$")
+    expect_identical(cache_dir, tempdir())
+    expect_identical(subdir, "gisco_metadata")
+    expect_true(verbose)
 
-      csv_file <- tempfile(fileext = ".csv")
-      write.csv(
-        data.frame(id = "ES", name = "Spain"),
-        csv_file,
-        row.names = FALSE,
-        fileEncoding = "UTF-8"
-      )
-      csv_file
-    }
-  )
+    csv_file <- tempfile(fileext = ".csv")
+    write.csv(
+      data.frame(id = "ES", name = "Spain"),
+      csv_file,
+      row.names = FALSE,
+      fileEncoding = "UTF-8"
+    )
+    csv_file
+  })
 
   metadata <- gisco_get_metadata("countries", year = 2024, verbose = TRUE)
   expect_s3_class(metadata, "tbl_df")
   expect_identical(metadata$id, "ES")
 })
 
-test_that("Messages", {
+test_that("Metadata reports downloads in verbose mode", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  expect_message(n <- gisco_get_metadata(verbose = TRUE))
+  expect_message(n <- gisco_get_metadata(verbose = TRUE), "Cache directory")
   expect_s3_class(n, "tbl_df")
 })
 
-test_that("Errors", {
+test_that("Metadata validates dataset and year inputs", {
   skip_on_cran()
   skip_if_gisco_offline()
   expect_snapshot(gisco_get_metadata("grids"), error = TRUE)
@@ -99,7 +92,7 @@ test_that("Errors", {
   expect_snapshot(gisco_get_metadata("urban_audit", year = 1990), error = TRUE)
 })
 
-test_that("Check all nuts", {
+test_that("Metadata is available for every NUTS year", {
   skip_on_cran()
   skip_if_gisco_offline()
   val_years <- db_values("nuts", "year", formatted = FALSE)
@@ -109,7 +102,7 @@ test_that("Check all nuts", {
   }
 })
 
-test_that("Check all countries", {
+test_that("Metadata is available for every countries year", {
   skip_on_cran()
   skip_if_gisco_offline()
   val_years <- db_values("countries", "year", formatted = FALSE)
@@ -119,7 +112,7 @@ test_that("Check all countries", {
   }
 })
 
-test_that("Check all urban_audit", {
+test_that("Metadata is available for every urban audit year", {
   skip_on_cran()
   skip_if_gisco_offline()
   val_years <- db_values("urban_audit", "year", formatted = FALSE)

--- a/tests/testthat/test-gisco-get-nuts.R
+++ b/tests/testthat/test-gisco-get-nuts.R
@@ -1,24 +1,18 @@
-test_that("Test offline", {
+test_that("NUTS return NULL when offline", {
   skip_on_cran()
   skip_if_gisco_offline()
 
   local_mocked_bindings(is_online_fun = function(...) {
     FALSE
   })
+  cdir <- local_test_cache_dir("testnuts-offline-")
   expect_message(
-    n <- gisco_get_nuts(
-      update_cache = TRUE,
-      cache_dir = tempdir(),
-      resolution = 60
-    ),
+    n <- gisco_get_nuts(update_cache = TRUE, cache_dir = cdir, resolution = 60),
     "No internet"
   )
   expect_null(n)
-  local_mocked_bindings(is_online_fun = function(...) {
-    httr2::is_online()
-  })
 })
-test_that("Test 404", {
+test_that("NUTS return NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -30,9 +24,6 @@ test_that("Test 404", {
     "Error"
   )
   expect_null(n)
-  local_mocked_bindings(is_404 = function(...) {
-    FALSE
-  })
 })
 
 test_that("NUTS use resolved GISCO files", {
@@ -80,7 +71,7 @@ test_that("NUTS use resolved GISCO files", {
   expect_identical(nuts$NUTS_ID, c("ES51", "FR1"))
 })
 
-test_that("Valid inputs", {
+test_that("NUTS validate extensions and level inputs", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -102,14 +93,11 @@ test_that("Valid inputs", {
   expect_identical(nrow(all[all$LEVL_CODE == 3, ]), nrow(l3))
 })
 
-test_that("Cached dataset vs updated", {
+test_that("NUTS can refresh an existing cached dataset", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "testnuts")
-  if (dir.exists(cdir)) {
-    unlink(cdir, recursive = TRUE, force = TRUE)
-  }
+  cdir <- local_test_cache_dir("testnuts-")
 
   expect_identical(list.files(cdir, recursive = TRUE), character(0))
   expect_snapshot(db_cached <- gisco_get_nuts(verbose = TRUE, nuts_id = "ES51"))
@@ -142,18 +130,13 @@ test_that("Cached dataset vs updated", {
   expect_identical(db_cached$NUTS_ID, db_cached2$NUTS_ID)
   expect_true("geo" %in% names(db_cached))
   expect_true("geo" %in% names(db_cached2))
-  # Cleanup
-  unlink(cdir, recursive = TRUE, force = TRUE)
 })
 
-test_that("Cache vs non-cached", {
+test_that("NUTS return matching data with and without cache", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "testnuts")
-  if (dir.exists(cdir)) {
-    unlink(cdir, recursive = TRUE, force = TRUE)
-  }
+  cdir <- local_test_cache_dir("testnuts-")
 
   expect_identical(list.files(cdir, recursive = TRUE), character(0))
   expect_message(
@@ -195,12 +178,9 @@ test_that("Cache vs non-cached", {
     cache = FALSE
   )
   expect_length(list.files(cdir, recursive = TRUE, pattern = "shp"), 1)
-
-  # Cleanup
-  unlink(cdir, recursive = TRUE, force = TRUE)
 })
 
-test_that("Filter countries", {
+test_that("NUTS can be filtered by country and level", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -240,7 +220,7 @@ test_that("Filter countries", {
   expect_identical(db_cached_full$NUTS_ID, "ES511")
 })
 
-test_that("Filter countries no cached", {
+test_that("NUTS filters also work without cache", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -267,7 +247,7 @@ test_that("Filter countries no cached", {
 
   expect_identical(nrow(bn), nrow(bn_nocach))
 })
-test_that("Spatial types", {
+test_that("NUTS support boundary and label spatial types", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -289,14 +269,11 @@ test_that("Spatial types", {
   )
 })
 
-test_that("Extensions", {
+test_that("NUTS support GeoJSON and zipped shapefile downloads", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "testnuts")
-  if (dir.exists(cdir)) {
-    unlink(cdir, recursive = TRUE, force = TRUE)
-  }
+  cdir <- local_test_cache_dir("testnuts-")
 
   expect_identical(list.files(cdir, recursive = TRUE), character(0))
 
@@ -323,7 +300,4 @@ test_that("Extensions", {
   expect_s3_class(db_zip, "tbl_df")
 
   expect_length(list.files(cdir, recursive = TRUE, pattern = "shp.zip"), 1)
-
-  # Cleanup
-  unlink(cdir, recursive = TRUE, force = TRUE)
 })

--- a/tests/testthat/test-gisco-get-ports.R
+++ b/tests/testthat/test-gisco-get-ports.R
@@ -1,4 +1,4 @@
-test_that("Offline", {
+test_that("Ports return NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -7,29 +7,26 @@ test_that("Offline", {
   })
   expect_message(n <- gisco_get_ports(update_cache = TRUE), "Error")
   expect_null(n)
-  local_mocked_bindings(is_404 = function(...) {
-    FALSE
-  })
 })
 
 test_that("Ports use the legacy geodata reader", {
-  local_mocked_bindings(
-    read_gisco_dataset = function(url,
-                                  cache_dir = NULL,
-                                  subdir,
-                                  update_cache = FALSE,
-                                  verbose = FALSE,
-                                  post_process = NULL,
-                                  ...) {
-      expect_match(url, "PORT_2013_SH[.]zip$")
-      expect_identical(cache_dir, "cache")
-      expect_identical(subdir, "ports")
-      expect_true(update_cache)
-      expect_true(verbose)
-      expect_identical(post_process, transform_to_wgs84)
-      data.frame(PORT_ID = c("ESBCN", "FRABC"))
-    }
-  )
+  local_mocked_bindings(read_gisco_dataset = function(
+    url,
+    cache_dir = NULL,
+    subdir,
+    update_cache = FALSE,
+    verbose = FALSE,
+    post_process = NULL,
+    ...
+  ) {
+    expect_match(url, "PORT_2013_SH[.]zip$")
+    expect_identical(cache_dir, "cache")
+    expect_identical(subdir, "ports")
+    expect_true(update_cache)
+    expect_true(verbose)
+    expect_identical(post_process, transform_to_wgs84)
+    data.frame(PORT_ID = c("ESBCN", "FRABC"))
+  })
 
   ports <- gisco_get_ports(
     country = "ES",
@@ -42,20 +39,18 @@ test_that("Ports use the legacy geodata reader", {
 })
 
 test_that("Ports select the 2009 file", {
-  local_mocked_bindings(
-    read_gisco_dataset = function(url, ...) {
-      expect_match(url, "PORT_2009_SH[.]zip$")
-      data.frame(PORT_ID = "ESBCN")
-    }
-  )
+  local_mocked_bindings(read_gisco_dataset = function(url, ...) {
+    expect_match(url, "PORT_2009_SH[.]zip$")
+    data.frame(PORT_ID = "ESBCN")
+  })
 
   ports <- gisco_get_ports(year = 2009)
   expect_identical(ports$CNTR_ISO2, "ES")
 })
 
-test_that("Get ports", {
-  expect_error(gisco_get_ports(year = 2020))
-  expect_error(gisco_get_ports(year = 2020, country = "ES"))
+test_that("Ports download current and legacy point data", {
+  expect_error(gisco_get_ports(year = 2020), "`year` must be")
+  expect_error(gisco_get_ports(year = 2020, country = "ES"), "`year` must be")
 
   skip_on_cran()
   skip_if_gisco_offline()

--- a/tests/testthat/test-gisco-get-postal-codes.R
+++ b/tests/testthat/test-gisco-get-postal-codes.R
@@ -1,11 +1,11 @@
-test_that("Error on postal codes", {
+test_that("Postal codes validate available years", {
   skip_on_cran()
   skip_if_gisco_offline()
 
   expect_error(gisco_get_postal_codes("1991", "Years available for"))
 })
 
-test_that("Offline", {
+test_that("Postal codes return NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -21,9 +21,6 @@ test_that("Offline", {
     "Error"
   )
   expect_null(n)
-  local_mocked_bindings(is_404 = function(...) {
-    FALSE
-  })
 })
 
 test_that("Postal codes use resolved GISCO files", {
@@ -83,13 +80,11 @@ test_that("Postal codes use resolved GISCO files", {
   expect_identical(postal_codes$CNTR_ID, c("MT", "LU"))
   expect_identical(
     filter_calls,
-    list(
-      list(
-        file_local = "postal_codes.gpkg",
-        values = c("MT", "LU"),
-        candidates = c("CNTR_ID", "CNTR_CODE")
-      )
-    )
+    list(list(
+      file_local = "postal_codes.gpkg",
+      values = c("MT", "LU"),
+      candidates = c("CNTR_ID", "CNTR_CODE")
+    ))
   )
 })
 
@@ -115,7 +110,7 @@ test_that("Postal codes select the requested EPSG", {
   expect_identical(postal_codes$CNTR_ID, "LU")
 })
 
-test_that("Extensions", {
+test_that("Postal codes reject unsupported extensions and read shapefiles", {
   skip_on_cran()
   skip_if_gisco_offline()
 

--- a/tests/testthat/test-gisco-get-unit-country.R
+++ b/tests/testthat/test-gisco-get-unit-country.R
@@ -1,4 +1,4 @@
-test_that("Test offline", {
+test_that("Country unit returns NULL when offline", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -15,12 +15,9 @@ test_that("Test offline", {
     "No internet"
   )
   expect_null(n)
-  local_mocked_bindings(is_online_fun = function(...) {
-    httr2::is_online()
-  })
 })
 
-test_that("Test 404", {
+test_that("Country unit returns NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -37,19 +34,13 @@ test_that("Test 404", {
     "Error"
   )
   expect_null(n)
-  local_mocked_bindings(is_404 = function(...) {
-    FALSE
-  })
 })
 
-test_that("unit_country: Greece", {
+test_that("Country unit reads Greece for several spatial types", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "test_unit")
-  if (dir.exists(cdir)) {
-    unlink(cdir, force = TRUE, recursive = TRUE)
-  }
+  cdir <- local_test_cache_dir("test-unit-")
   years <- db_values("countries", "year", formatted = FALSE)
 
   for (y in years) {
@@ -64,18 +55,13 @@ test_that("unit_country: Greece", {
     expect_s3_class(gr, "sf")
     expect_s3_class(gr, "tbl_df")
   }
-
-  if (dir.exists(cdir)) unlink(cdir, force = TRUE, recursive = TRUE)
 })
 
-test_that("unit_country: Caching", {
+test_that("Country unit returns matching data with and without cache", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "test_unit")
-  if (dir.exists(cdir)) {
-    unlink(cdir, force = TRUE, recursive = TRUE)
-  }
+  cdir <- local_test_cache_dir("test-unit-")
   expect_identical(list.files(cdir, recursive = TRUE), character(0))
 
   # Not caching
@@ -117,18 +103,13 @@ test_that("unit_country: Caching", {
     ),
     "File already cached"
   )
-
-  if (dir.exists(cdir)) unlink(cdir, force = TRUE, recursive = TRUE)
 })
 
-test_that("unit_country: Multi calls", {
+test_that("Country unit supports multiple calls and countries", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "test_unit")
-  if (dir.exists(cdir)) {
-    unlink(cdir, force = TRUE, recursive = TRUE)
-  }
+  cdir <- local_test_cache_dir("test-unit-")
 
   # Message even when verbose FALSE
   expect_message(
@@ -171,11 +152,9 @@ test_that("unit_country: Multi calls", {
   )
   expect_equal(nrow(pol), 3)
   expect_true(all(sf::st_geometry_type(pol) == "POLYGON"))
-
-  if (dir.exists(cdir)) unlink(cdir, force = TRUE, recursive = TRUE)
 })
 
-test_that("unit_country: Validate inputs", {
+test_that("Country unit validates year, EPSG, resolution and spatial type", {
   skip_on_cran()
   skip_if_gisco_offline()
   expect_snapshot(gisco_get_unit_country(year = -1989), error = TRUE)

--- a/tests/testthat/test-gisco-get-unit-nuts.R
+++ b/tests/testthat/test-gisco-get-unit-nuts.R
@@ -1,4 +1,4 @@
-test_that("Test offline", {
+test_that("NUTS unit returns NULL when offline", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -10,12 +10,9 @@ test_that("Test offline", {
     "No internet"
   )
   expect_null(n)
-  local_mocked_bindings(is_online_fun = function(...) {
-    httr2::is_online()
-  })
 })
 
-test_that("Test 404", {
+test_that("NUTS unit returns NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -27,19 +24,13 @@ test_that("Test 404", {
     "Error"
   )
   expect_null(n)
-  local_mocked_bindings(is_404 = function(...) {
-    FALSE
-  })
 })
 
-test_that("unit_nuts: ES416", {
+test_that("NUTS unit reads ES416 for several spatial types", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "test_unit_nuts")
-  if (dir.exists(cdir)) {
-    unlink(cdir, force = TRUE, recursive = TRUE)
-  }
+  cdir <- local_test_cache_dir("test-unit-nuts-")
   years <- db_values("nuts", "year", formatted = FALSE)
 
   for (y in years) {
@@ -55,18 +46,13 @@ test_that("unit_nuts: ES416", {
     expect_s3_class(gr, "sf")
     expect_s3_class(gr, "tbl_df")
   }
-
-  if (dir.exists(cdir)) unlink(cdir, force = TRUE, recursive = TRUE)
 })
 
-test_that("unit_nuts: Caching", {
+test_that("NUTS unit returns matching data with and without cache", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "test_unit_nuts")
-  if (dir.exists(cdir)) {
-    unlink(cdir, force = TRUE, recursive = TRUE)
-  }
+  cdir <- local_test_cache_dir("test-unit-nuts-")
   expect_identical(list.files(cdir, recursive = TRUE), character(0))
 
   # Not caching
@@ -112,18 +98,13 @@ test_that("unit_nuts: Caching", {
     "File already cached"
   )
   expect_identical(rev(names(g))[1:2], c("geometry", "geo"))
-
-  if (dir.exists(cdir)) unlink(cdir, force = TRUE, recursive = TRUE)
 })
 
-test_that("unit_nuts: Multi calls", {
+test_that("NUTS unit supports multiple calls and units", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "test_unit_nuts")
-  if (dir.exists(cdir)) {
-    unlink(cdir, force = TRUE, recursive = TRUE)
-  }
+  cdir <- local_test_cache_dir("test-unit-nuts-")
 
   # Message even when verbose FALSE
   expect_message(
@@ -166,11 +147,9 @@ test_that("unit_nuts: Multi calls", {
   )
   expect_equal(nrow(pol), 3)
   expect_true(all(sf::st_geometry_type(pol) == "POLYGON"))
-
-  if (dir.exists(cdir)) unlink(cdir, force = TRUE, recursive = TRUE)
 })
 
-test_that("unit_nuts: Validate inputs", {
+test_that("NUTS unit validates year, EPSG, resolution and spatial type", {
   skip_on_cran()
   skip_if_gisco_offline()
   expect_snapshot(gisco_get_unit_nuts(year = -1989), error = TRUE)

--- a/tests/testthat/test-gisco-get-unit-urban-audit.R
+++ b/tests/testthat/test-gisco-get-unit-urban-audit.R
@@ -1,4 +1,4 @@
-test_that("Test offline", {
+test_that("Urban audit unit returns NULL when offline", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -14,12 +14,9 @@ test_that("Test offline", {
     "No internet"
   )
   expect_null(n)
-  local_mocked_bindings(is_online_fun = function(...) {
-    httr2::is_online()
-  })
 })
 
-test_that("Test 404", {
+test_that("Urban audit unit returns NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -35,19 +32,13 @@ test_that("Test 404", {
     "Error"
   )
   expect_null(n)
-  local_mocked_bindings(is_404 = function(...) {
-    FALSE
-  })
 })
 
-test_that("unit_urau: Several years", {
+test_that("Urban audit unit reads city geometries for several years", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "test_unit_urau")
-  if (dir.exists(cdir)) {
-    unlink(cdir, force = TRUE, recursive = TRUE)
-  }
+  cdir <- local_test_cache_dir("test-unit-urau-")
   years <- db_values("urban_audit", "year", formatted = FALSE)
 
   for (y in years) {
@@ -63,17 +54,12 @@ test_that("unit_urau: Several years", {
     expect_s3_class(gr, "sf")
     expect_s3_class(gr, "tbl_df")
   }
-
-  if (dir.exists(cdir)) unlink(cdir, force = TRUE, recursive = TRUE)
 })
-test_that("unit_urau: Several years polygon", {
+test_that("Urban audit unit reads polygon geometries for several years", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "test_unit_urau")
-  if (dir.exists(cdir)) {
-    unlink(cdir, force = TRUE, recursive = TRUE)
-  }
+  cdir <- local_test_cache_dir("test-unit-urau-")
   years <- db_values("urban_audit", "year", formatted = FALSE)
 
   for (y in years) {
@@ -89,18 +75,13 @@ test_that("unit_urau: Several years polygon", {
     expect_s3_class(gr, "sf")
     expect_s3_class(gr, "tbl_df")
   }
-
-  if (dir.exists(cdir)) unlink(cdir, force = TRUE, recursive = TRUE)
 })
 
-test_that("unit_urau: Caching", {
+test_that("Urban audit unit returns matching data with and without cache", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "test_unit_urau")
-  if (dir.exists(cdir)) {
-    unlink(cdir, force = TRUE, recursive = TRUE)
-  }
+  cdir <- local_test_cache_dir("test-unit-urau-")
   expect_identical(list.files(cdir, recursive = TRUE), character(0))
 
   # Not caching
@@ -139,18 +120,13 @@ test_that("unit_urau: Caching", {
     ),
     "File already cached"
   )
-
-  if (dir.exists(cdir)) unlink(cdir, force = TRUE, recursive = TRUE)
 })
 
-test_that("unit_urau: Multi calls", {
+test_that("Urban audit unit supports multiple calls and units", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "test_unit_urau")
-  if (dir.exists(cdir)) {
-    unlink(cdir, force = TRUE, recursive = TRUE)
-  }
+  cdir <- local_test_cache_dir("test-unit-urau-")
 
   # Message even when verbose FALSE
   expect_message(
@@ -192,11 +168,9 @@ test_that("unit_urau: Multi calls", {
   )
   expect_equal(nrow(pol), 3)
   expect_true(all(sf::st_geometry_type(pol) == "MULTIPOLYGON"))
-
-  if (dir.exists(cdir)) unlink(cdir, force = TRUE, recursive = TRUE)
 })
 
-test_that("unit_urban_audit: Validate inputs", {
+test_that("Urban audit unit validates year, EPSG and spatial type", {
   skip_on_cran()
   skip_if_gisco_offline()
   expect_snapshot(gisco_get_unit_urban_audit(year = -1989), error = TRUE)

--- a/tests/testthat/test-gisco-get-urban-audit.R
+++ b/tests/testthat/test-gisco-get-urban-audit.R
@@ -1,15 +1,18 @@
-test_that("Urban Audit offline", {
+test_that("Urban audit validates inputs before remote access", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  expect_error(gisco_get_urban_audit(year = "1999"))
-  expect_error(gisco_get_urban_audit(epsg = "9999"))
-  expect_error(gisco_get_urban_audit(level = "9999"))
-  expect_error(gisco_get_urban_audit(spatialtype = "BN"))
-  expect_error(gisco_get_urban_audit(year = 2001))
+  expect_error(gisco_get_urban_audit(year = "1999"), "Years available")
+  expect_error(gisco_get_urban_audit(epsg = "9999"), "No results")
+  expect_error(gisco_get_urban_audit(level = "9999"), "`level` must be")
+  expect_error(
+    gisco_get_urban_audit(spatialtype = "BN"),
+    "`spatialtype` must be"
+  )
+  expect_error(gisco_get_urban_audit(year = 2001), "No results")
 })
 
-test_that("Mock offline", {
+test_that("Urban audit returns NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -18,9 +21,6 @@ test_that("Mock offline", {
   })
   expect_message(n <- gisco_get_urban_audit(update_cache = TRUE), "Error")
   expect_null(n)
-  local_mocked_bindings(is_404 = function(...) {
-    FALSE
-  })
 })
 
 test_that("Urban Audit uses resolved GISCO files", {
@@ -66,7 +66,7 @@ test_that("Urban Audit uses resolved GISCO files", {
   expect_identical(urban$CNTR_CODE, "LU")
 })
 
-test_that("Urban Audit online", {
+test_that("Urban audit downloads and filters online data", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -145,7 +145,7 @@ test_that("Urban Audit online", {
   expect_length(setdiff(unique(check$CNTR_CODE), c("IT", "PL")), 0)
 })
 
-test_that("Test inputs", {
+test_that("Urban audit validates extensions and level inputs", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -158,14 +158,11 @@ test_that("Test inputs", {
   expect_identical(db_null, db_all)
 })
 
-test_that("Cache vs non-cached", {
+test_that("Urban audit returns matching data with and without cache", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "testurbanaudit")
-  if (dir.exists(cdir)) {
-    unlink(cdir, recursive = TRUE, force = TRUE)
-  }
+  cdir <- local_test_cache_dir("testurbanaudit-")
 
   expect_identical(list.files(cdir, recursive = TRUE), character(0))
   expect_message(
@@ -210,18 +207,12 @@ test_that("Cache vs non-cached", {
     cache = FALSE
   )
   expect_length(list.files(cdir, recursive = TRUE, pattern = "shp"), 1)
-
-  # Cleanup
-  unlink(cdir, recursive = TRUE, force = TRUE)
 })
-test_that("Extensions", {
+test_that("Urban audit supports GeoJSON and zipped shapefile downloads", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "testurbanaudit")
-  if (dir.exists(cdir)) {
-    unlink(cdir, recursive = TRUE, force = TRUE)
-  }
+  cdir <- local_test_cache_dir("testurbanaudit-")
 
   expect_identical(list.files(cdir, recursive = TRUE), character(0))
 
@@ -246,7 +237,4 @@ test_that("Extensions", {
   expect_s3_class(db_zip, "tbl_df")
 
   expect_length(list.files(cdir, recursive = TRUE, pattern = "shp.zip"), 1)
-
-  # Cleanup
-  unlink(cdir, recursive = TRUE, force = TRUE)
 })

--- a/tests/testthat/test-gisco-id-api.R
+++ b/tests/testthat/test-gisco-id-api.R
@@ -1,4 +1,4 @@
-test_that("Test offline", {
+test_that("ID API returns NULL when offline", {
   skip_on_cran()
   skip_if_gisco_offline()
   local_mocked_bindings(is_online_fun = function(...) {
@@ -11,13 +11,9 @@ test_that("Test offline", {
   # json
   expect_snapshot(fend <- gisco_id_api_nuts(x = 4, y = 52, geometry = FALSE))
   expect_null(fend)
-
-  local_mocked_bindings(is_online_fun = function(...) {
-    httr2::is_online()
-  })
 })
 
-test_that("Test 404", {
+test_that("ID API returns NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -41,38 +37,33 @@ test_that("Test 404", {
     "Error"
   )
   expect_null(n)
-  local_mocked_bindings(is_404 = function(...) {
-    FALSE
-  })
 })
 
 test_that("ID API delegates GeoJSON responses to the spatial reader", {
-  local_mocked_bindings(
-    read_id_api_geojson = function(url, verbose = FALSE) {
-      expect_match(url, "format=geojson")
-      expect_true(verbose)
-      data.frame(id = "ES")
-    }
-  )
+  local_mocked_bindings(read_id_api_geojson = function(url, verbose = FALSE) {
+    expect_match(url, "format=geojson")
+    expect_true(verbose)
+    data.frame(id = "ES")
+  })
 
   out <- gisco_id_api_country(x = 1, y = 2, verbose = TRUE)
   expect_identical(out$id, "ES")
 })
 
 test_that("ID API delegates JSON responses to the JSON helper", {
-  local_mocked_bindings(
-    call_gisco_json_api = function(custom_query,
-                                   apiurl,
-                                   result_field,
-                                   verbose = FALSE) {
-      expect_identical(custom_query$format, "json")
-      expect_identical(custom_query$geometry, "no")
-      expect_match(apiurl, "country")
-      expect_identical(result_field, "attributes")
-      expect_true(verbose)
-      data.frame(id = "ES")
-    }
-  )
+  local_mocked_bindings(call_gisco_json_api = function(
+    custom_query,
+    apiurl,
+    result_field,
+    verbose = FALSE
+  ) {
+    expect_identical(custom_query$format, "json")
+    expect_identical(custom_query$geometry, "no")
+    expect_match(apiurl, "country")
+    expect_identical(result_field, "attributes")
+    expect_true(verbose)
+    data.frame(id = "ES")
+  })
 
   out <- gisco_id_api_country(x = 1, y = 2, geometry = FALSE, verbose = TRUE)
   expect_identical(out$id, "ES")

--- a/tests/testthat/test-utils-country.R
+++ b/tests/testthat/test-utils-country.R
@@ -1,5 +1,6 @@
-test_that("Utils names", {
+test_that("Country code conversion handles standard names and codes", {
   skip_on_cran()
+  skip_if_gisco_offline()
 
   expect_null(convert_country_code_or_null(NULL))
   expect_identical(convert_country_code_or_null("ES"), "ES")
@@ -11,10 +12,7 @@ test_that("Utils names", {
 })
 
 test_that("Country column filter works", {
-  data <- data.frame(
-    CNTR_CODE = c("ES", "FR", "PT"),
-    value = 1:3
-  )
+  data <- data.frame(CNTR_CODE = c("ES", "FR", "PT"), value = 1:3)
 
   expect_identical(filter_by_country_col(data, NULL), data)
   expect_identical(filter_by_country_col(data, "ES")$value, 1L)
@@ -22,8 +20,9 @@ test_that("Country column filter works", {
   expect_identical(filter_by_country_col(data, "ES", "missing"), data)
 })
 
-test_that("Problematic names", {
+test_that("Country code conversion reports unresolved names", {
   skip_on_cran()
+  skip_if_gisco_offline()
 
   expect_snapshot(convert_country_code(c("Espagne", "Antartica")))
   expect_snapshot(convert_country_code(c("spain", "antartica")))
@@ -49,8 +48,9 @@ test_that("Problematic names", {
   expect_identical(convert_country_code("ES"), "ES")
 })
 
-test_that("Test mixed countries", {
+test_that("Country filters accept mixed country identifiers", {
   skip_on_cran()
+  skip_if_gisco_offline()
 
   expect_snapshot(convert_country_code(c(
     "Germany",
@@ -60,8 +60,9 @@ test_that("Test mixed countries", {
   )))
 })
 
-test_that("Get regions and countries", {
+test_that("Country region filters return matching country codes", {
   skip_on_cran()
+  skip_if_gisco_offline()
 
   expect_null(get_countrycodes_region())
   expect_identical(get_countrycodes_region(c("Japan", "Spain")), c("JP", "ES"))

--- a/tests/testthat/test-utils-sf.R
+++ b/tests/testthat/test-utils-sf.R
@@ -1,11 +1,8 @@
-test_that("Read shp", {
+test_that("Spatial reader imports downloaded shapefiles", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "testthat_ex")
-  if (dir.exists(cdir)) {
-    unlink(cdir, recursive = TRUE, force = TRUE)
-  }
+  cdir <- local_test_cache_dir("testthat-ex-")
   url <- paste0(
     "https://gisco-services.ec.europa.eu/distribution/v2/countries/",
     "shp/CNTR_LB_2024_4326.shp.zip"
@@ -36,18 +33,13 @@ test_that("Read shp", {
     q = "SELECT * from \"CNTR_LB_2024_4326\" LIMIT 1"
   )
   expect_equal(sq, s[1, ])
-  unlink(cdir, recursive = TRUE, force = TRUE)
-  expect_false(dir.exists(cdir))
 })
 
-test_that("Read gpkg", {
+test_that("Spatial reader imports downloaded GeoPackages", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "testthat_ex")
-  if (dir.exists(cdir)) {
-    unlink(cdir, recursive = TRUE, force = TRUE)
-  }
+  cdir <- local_test_cache_dir("testthat-ex-")
   url <- paste0(
     "https://gisco-services.ec.europa.eu/distribution/v2/countries/",
     "gpkg/CNTR_LB_2024_4326.gpkg"
@@ -99,7 +91,4 @@ test_that("Read gpkg", {
 
   # From url doesn't warn
   expect_silent(f2 <- read_geo_file_sf(url))
-
-  unlink(cdir, recursive = TRUE, force = TRUE)
-  expect_false(dir.exists(cdir))
 })

--- a/tests/testthat/test-utils-url.R
+++ b/tests/testthat/test-utils-url.R
@@ -1,24 +1,15 @@
 test_that("GISCO URL helpers work", {
-  expect_identical(
-    gisco_services_url(),
-    "https://gisco-services.ec.europa.eu"
-  )
+  expect_identical(gisco_services_url(), "https://gisco-services.ec.europa.eu")
   expect_identical(
     gisco_distribution_url(),
     "https://gisco-services.ec.europa.eu/distribution/v2/"
   )
-  expect_identical(
-    gisco_id_url(),
-    "https://gisco-services.ec.europa.eu/id/"
-  )
+  expect_identical(gisco_id_url(), "https://gisco-services.ec.europa.eu/id/")
   expect_identical(
     gisco_address_url(),
     "https://gisco-services.ec.europa.eu/addressapi/"
   )
-  expect_identical(
-    gisco_pub_url(),
-    "https://gisco-services.ec.europa.eu/pub/"
-  )
+  expect_identical(gisco_pub_url(), "https://gisco-services.ec.europa.eu/pub/")
   expect_identical(
     eurostat_gisco_geodata_url("PORT_2013_SH.zip"),
     paste0(
@@ -48,11 +39,9 @@ test_that("Packaged dataset helper returns matching data", {
 })
 
 test_that("GISCO file resolver returns URL and file name", {
-  local_mocked_bindings(
-    get_url_db = function(...) {
-      "https://example.com/path/file.gpkg"
-    }
-  )
+  local_mocked_bindings(get_url_db = function(...) {
+    "https://example.com/path/file.gpkg"
+  })
 
   file <- resolve_gisco_file("countries", year = 2024, fn = "test")
   expect_identical(file$url, "https://example.com/path/file.gpkg")
@@ -106,21 +95,16 @@ test_that("Dataset reader delegates cache and non-cache paths", {
 
 test_that("JSON API helper returns requested field", {
   response <- list(results = data.frame(id = 1:2, name = c("a", "b")))
-  local_mocked_bindings(
-    get_request_body = function(url, verbose = FALSE) {
-      expect_match(url, "q=test")
-      structure(response, class = "mock_response")
-    }
-  )
-  local_mocked_bindings(
-    .package = "httr2",
-    resp_body_json = function(resp, ...) {
-      args <- list(...)
-      expect_s3_class(resp, "mock_response")
-      expect_true(args$simplifyVector)
-      unclass(resp)
-    }
-  )
+  local_mocked_bindings(get_request_body = function(url, verbose = FALSE) {
+    expect_match(url, "q=test")
+    structure(response, class = "mock_response")
+  })
+  local_mocked_bindings(gisco_resp_body_json = function(resp, ...) {
+    args <- list(...)
+    expect_s3_class(resp, "mock_response")
+    expect_true(args$simplifyVector)
+    unclass(resp)
+  })
 
   result <- call_gisco_json_api(
     custom_query = list(q = "test"),
@@ -133,9 +117,7 @@ test_that("JSON API helper returns requested field", {
 })
 
 test_that("JSON API helper returns NULL for missing responses", {
-  local_mocked_bindings(
-    get_request_body = function(...) NULL
-  )
+  local_mocked_bindings(get_request_body = function(...) NULL)
 
   expect_null(call_gisco_json_api(
     custom_query = list(q = "test"),
@@ -144,7 +126,7 @@ test_that("JSON API helper returns NULL for missing responses", {
   ))
 })
 
-test_that("Test offline", {
+test_that("Downloads return NULL when offline", {
   skip_on_cran()
   skip_if_gisco_offline()
   local_mocked_bindings(is_online_fun = function(...) {
@@ -155,10 +137,7 @@ test_that("Test offline", {
     "https://gisco-services.ec.europa.eu/distribution/v2/",
     "nuts/geojson/NUTS_LB_2016_4326_LEVL_0.geojson"
   )
-  cdir <- file.path(tempdir(), "testthat_ex")
-  if (dir.exists(cdir)) {
-    unlink(cdir, recursive = TRUE, force = TRUE)
-  }
+  cdir <- local_test_cache_dir("testthat-ex-")
   expect_snapshot(
     fend <- download_url(
       url,
@@ -170,22 +149,13 @@ test_that("Test offline", {
   )
   expect_null(fend)
   expect_length(list.files(cdir, recursive = TRUE), 0)
-  unlink(cdir, recursive = TRUE, force = TRUE)
-
-  local_mocked_bindings(is_online_fun = function(...) {
-    httr2::is_online()
-  })
-  expect_identical(is_online_fun(), httr2::is_online())
 })
 
-test_that("Test 404", {
+test_that("Downloads return NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "testthat_ex")
-  if (dir.exists(cdir)) {
-    unlink(cdir, recursive = TRUE, force = TRUE)
-  }
+  cdir <- local_test_cache_dir("testthat-ex-")
 
   local_mocked_bindings(is_404 = function(...) {
     TRUE
@@ -205,12 +175,18 @@ test_that("Test 404", {
     "Error "
   )
   expect_null(s)
+})
 
-  local_mocked_bindings(is_404 = function(...) {
-    FALSE
-  })
+test_that("Download works after remote file is available", {
+  skip_on_cran()
+  skip_if_gisco_offline()
 
-  # Otherwise work
+  cdir <- local_test_cache_dir("testthat-ex-")
+
+  url <- paste0(
+    "https://gisco-services.ec.europa.eu/distribution/v2/countries/",
+    "shp/CNTR_LB_2024_4326.shp.zip"
+  )
   expect_silent(
     s <- download_url(
       url,
@@ -221,12 +197,9 @@ test_that("Test 404", {
   )
   expect_length(s, 1)
   expect_type(s, "character")
-  if (dir.exists(cdir)) {
-    unlink(cdir, recursive = TRUE, force = TRUE)
-  }
 })
 
-test_that("Caching tests", {
+test_that("Downloads reuse and refresh cached files", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -234,10 +207,7 @@ test_that("Caching tests", {
     "https://gisco-services.ec.europa.eu/distribution/v2/",
     "nuts/geojson/NUTS_LB_2016_4326_LEVL_0.geojson"
   )
-  cdir <- file.path(tempdir(), "testthat_ex")
-  if (dir.exists(cdir)) {
-    unlink(cdir, recursive = TRUE, force = TRUE)
-  }
+  cdir <- local_test_cache_dir("testthat-ex-")
   expect_message(
     fend <- download_url(
       url,
@@ -272,11 +242,9 @@ test_that("Caching tests", {
     ),
     "Updating cached"
   )
-
-  unlink(cdir, recursive = TRUE, force = TRUE)
 })
 
-test_that("Caching errors", {
+test_that("Downloads report missing remote files", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -284,10 +252,7 @@ test_that("Caching errors", {
     "https://gisco-services.ec.europa.eu/distribution/v2/",
     "fake-file.txt"
   )
-  cdir <- file.path(tempdir(), "testthat_ex")
-  if (dir.exists(cdir)) {
-    unlink(cdir, recursive = TRUE, force = TRUE)
-  }
+  cdir <- local_test_cache_dir("testthat-ex-")
   expect_message(
     fend <- download_url(
       url,
@@ -315,11 +280,9 @@ test_that("Caching errors", {
     ),
     "The file to download is"
   )
-
-  unlink(cdir, recursive = TRUE, force = TRUE)
 })
 
-test_that("Get urls", {
+test_that("URL database lookup validates and returns matching entries", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -400,7 +363,7 @@ test_that("Get urls", {
   expect_equal(httr2::resp_status(resp), 200)
 })
 
-test_that("No connection body", {
+test_that("Request body returns NULL when offline", {
   skip_on_cran()
   skip_if_gisco_offline()
   local_mocked_bindings(is_online_fun = function(...) {
@@ -414,13 +377,9 @@ test_that("No connection body", {
 
   expect_snapshot(fend <- get_request_body(url, verbose = FALSE))
   expect_null(fend)
-  local_mocked_bindings(is_online_fun = function(...) {
-    httr2::is_online()
-  })
-  expect_identical(is_online_fun(), httr2::is_online())
 })
 
-test_that("Error body", {
+test_that("Request body returns NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
   local_mocked_bindings(is_404 = function(...) {
@@ -433,12 +392,9 @@ test_that("Error body", {
 
   expect_snapshot(fend <- get_request_body(url, verbose = FALSE))
   expect_null(fend)
-  local_mocked_bindings(is_404 = function(...) {
-    FALSE
-  })
 })
 
-test_that("Tests body", {
+test_that("Request body returns content for successful responses", {
   skip_on_cran()
   skip_if_gisco_offline()
 
@@ -461,44 +417,37 @@ test_that("Tests body", {
   expect_null(fend)
 })
 
-test_that("Test import jsonlite with missing response", {
-  local_mocked_bindings(
-    get_request_body = function(...) NULL
-  )
+test_that("JSON import returns NULL for missing responses", {
+  local_mocked_bindings(get_request_body = function(...) NULL)
 
   expect_null(for_import_jsonlite())
 })
 
-test_that("Test import jsonlite with mocked response body", {
-  local_mocked_bindings(
-    get_request_body = function(url, verbose = FALSE) {
-      expect_identical(
-        url,
-        "https://ropengov.github.io/giscoR/search.json"
-      )
-      expect_false(verbose)
-      structure(list(), class = "mock_response")
-    }
-  )
-  local_mocked_bindings(
-    .package = "httr2",
-    resp_body_string = function(resp) {
-      expect_s3_class(resp, "mock_response")
-      "{\"items\":[]}"
-    }
-  )
+test_that("JSON import parses mocked response bodies", {
+  local_mocked_bindings(get_request_body = function(url, verbose = FALSE) {
+    expect_identical(url, "https://ropengov.github.io/giscoR/search.json")
+    expect_false(verbose)
+    structure(list(), class = "mock_response")
+  })
+  local_mocked_bindings(gisco_resp_body_string = function(resp) {
+    expect_s3_class(resp, "mock_response")
+    "{\"items\":[]}"
+  })
 
   expect_null(for_import_jsonlite())
 })
 
-test_that("Test timeout", {
+test_that("Response body string wrapper delegates to httr2", {
+  resp <- httr2::response(200, body = charToRaw("abc"))
+
+  expect_identical(gisco_resp_body_string(resp), "abc")
+})
+
+test_that("Downloads retry successfully after a timeout", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  cdir <- file.path(tempdir(), "testthat_timeout")
-  if (dir.exists(cdir)) {
-    unlink(cdir, recursive = TRUE, force = TRUE)
-  }
+  cdir <- local_test_cache_dir("testthat-timeout-")
 
   url <- paste0(
     "https://gisco-services.ec.europa.eu/distribution/v2/",
@@ -517,6 +466,4 @@ test_that("Test timeout", {
   )
 
   expect_true(file.exists(ff))
-  unlink(cdir, recursive = TRUE, force = TRUE)
-  expect_false(file.exists(ff))
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,5 +1,6 @@
-test_that("Messages", {
+test_that("Message helper emits each supported message type", {
   skip_on_cran()
+  skip_if_gisco_offline()
   expect_silent(make_msg(verbose = FALSE))
   expect_snapshot(make_msg(
     "generic",
@@ -22,8 +23,9 @@ test_that("Messages", {
   expect_snapshot(make_msg("success", TRUE, "Hooray!", "5/5 ;)"))
 })
 
-test_that("Pretty match", {
+test_that("Argument matcher reports exact and invalid values", {
   skip_on_cran()
+  skip_if_gisco_offline()
   my_fun <- function(arg_one = c(10, 1000, 3000, 5000)) {
     match_arg_pretty(arg_one)
   }
@@ -102,8 +104,9 @@ test_that("Deprecated cache helper warns only when cache is supplied", {
   expect_snapshot(warn_deprecated_cache(TRUE, "x(cache)"))
 })
 
-test_that("Bind and fill sf", {
+test_that("rbind_fill combines sf inputs with different schemas", {
   skip_on_cran()
+  skip_if_gisco_offline()
   gb <- giscoR::gisco_countries_2024[1, ]
   cos <- giscoR::gisco_nuts_2024[1, ]
   a_list <- list(gb, cos, gb, cos)
@@ -114,8 +117,9 @@ test_that("Bind and fill sf", {
   expect_equal(nrow(binded), 4)
 })
 
-test_that("Bind and fill tibbles", {
+test_that("rbind_fill combines tibble inputs with different schemas", {
   skip_on_cran()
+  skip_if_gisco_offline()
   gb <- giscoR::gisco_countries_2024[1, ]
   gb <- sf::st_drop_geometry(gb)
   cos <- giscoR::gisco_nuts_2024[1, ]
@@ -127,8 +131,9 @@ test_that("Bind and fill tibbles", {
   expect_equal(nrow(binded), 4)
 })
 
-test_that("Bind and fill sf removes NULL", {
+test_that("rbind_fill drops NULL entries from sf input lists", {
   skip_on_cran()
+  skip_if_gisco_offline()
   gb <- giscoR::gisco_countries_2024[1, ]
   cos <- giscoR::gisco_nuts_2024[1, ]
   a_list <- list(gb, cos, gb, cos)
@@ -140,8 +145,9 @@ test_that("Bind and fill sf removes NULL", {
   expect_equal(nrow(binded), 3)
 })
 
-test_that("Bind and fill tibble removes NULL", {
+test_that("rbind_fill drops NULL entries from tibble input lists", {
   skip_on_cran()
+  skip_if_gisco_offline()
   gb <- giscoR::gisco_countries_2024[1, ]
   gb <- sf::st_drop_geometry(gb)
   cos <- giscoR::gisco_nuts_2024[1, ]
@@ -159,7 +165,7 @@ test_that("Bind and fill tibble removes NULL", {
 
   expect_null(rbind_fill(new_l))
 })
-test_that("Ensure NULL", {
+test_that("ensure_null handles empty-like and non-empty values", {
   expect_null(ensure_null(NULL))
   expect_null(ensure_null(c(NULL, NA)))
   expect_null(ensure_null(c(NULL, NA, "")))
@@ -168,17 +174,9 @@ test_that("Ensure NULL", {
   expect_identical(letters, letters)
 })
 
-test_that("Ensure NULL", {
-  expect_null(ensure_null(NULL))
-  expect_null(ensure_null(c(NULL, NA)))
-  expect_null(ensure_null(c(NULL, NA, "")))
-  expect_null(ensure_null(c("", character(0))))
-  expect_identical(ensure_null(c(1, 2)), c(1, 2))
-  expect_identical(letters, letters)
-})
-
-test_that("Test cli_abort_if_not", {
+test_that("cli_abort_if_not aborts when conditions fail", {
   skip_on_cran()
+  skip_if_gisco_offline()
 
   expect_silent(cli_abort_if_not("Noting" = is.logical(TRUE)))
 


### PR DESCRIPTION
## Summary

This PR refactors and hardens the test suite around cache isolation and external-service behavior.

- isolates GISCO cache writes in tests with temporary cache directories
- adds wrappers/mocks for user config and response body helpers where needed
- improves test descriptions and removes redundant cleanup/duplicate checks
- covers `R/gisco-cache.R` and `R/utils-url.R` to 100% with `test_coverage_active_file()`
- refreshes generated docs and metadata with `pkgdev::update_docs()`

## Validation

- `pkgdev::update_docs()`
- `devtools::load_all()`
- `devtools::lint()`
- `devtools::test_coverage_active_file("./R/gisco-cache.R", report = "silent")` -> 100%
- `devtools::test_coverage_active_file("./R/utils-url.R", report = "silent")` -> 100%
- static check that every `skip_on_cran()` is followed by `skip_if_gisco_offline()`

Global test execution was intentionally left to the maintainer during the refactor.