### PR TITLE
Align tests with AGENTS.md guidance

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,9 @@
 # Contributing to giscoR
 
-This outlines how to propose a change to **giscoR**.
+This outlines how to propose a change to giscoR. For a detailed discussion on
+contributing to this package, please see the [development contributing
+guide](https://rstd.io/tidy-contrib) and our [code review
+principles](https://code-review.tidyverse.org/).
 
 ## Fixing typos
 
@@ -22,43 +25,44 @@ issue](https://code-review.tidyverse.org/issues/) for more advice.
 
 ### Pull request process
 
--   Fork the package and clone onto your computer. If you haven't done this
-    before, we recommend using
-    `usethis::create_from_github("rOpenGov/giscoR", fork = TRUE)`.
+- Fork the package and clone onto your computer. If you haven't done this
+  before, we recommend using
+  `usethis::create_from_github("rOpenGov/giscoR", fork = TRUE)`.
 
--   Install all development dependencies with `devtools::install_dev_deps()`,
-    and then make sure the package passes R CMD check by running
-    `devtools::check()`. If R CMD check doesn't pass cleanly, it's a good idea
-    to ask for help before continuing.
+- Install all development dependencies with `pak::local_install_dev_deps()`, and
+  then make sure the package passes `R CMD check` by running
+  `devtools::check()`. If `R CMD check` doesn't pass cleanly, it's a good idea
+  to ask for help before continuing.
 
--   Create a Git branch for your pull request (PR). We recommend using
-    `usethis::pr_init("brief-description-of-change")`.
+- Create a Git branch for your pull request (PR). We recommend using
+  `usethis::pr_init("brief-description-of-change")`.
 
--   Make your changes, commit to git, and then create a PR by running
-    `usethis::pr_push()`, and following the prompts in your browser. The title
-    of your PR should briefly describe the change. The body of your PR should
-    contain `Fixes #issue-number`.
+- Make your changes and check that the package passes `R CMD check` by running
+  `devtools::check()` again. Commit the changes to git, and then create a PR by
+  running `usethis::pr_push()`, and follow the prompts in your browser. The
+  title of your PR should briefly describe the change. The body of your PR
+  should contain `Fixes #issue-number`.
 
--   For user-facing changes, add a bullet to the top of `NEWS.md` (i.e. just
-    below the first header). Follow the style described in
-    <https://style.tidyverse.org/news.html>.
+- For user-facing changes, add a bullet to the top of `NEWS.md` (i.e. just below
+  the first header). Follow the style described in
+  <https://style.tidyverse.org/news.html>.
 
 ### Code style
 
--   New code should follow the tidyverse [style
-    guide](https://style.tidyverse.org). You can use
-    [Air](https://posit-dev.github.io/air/) to apply this style, but please
-    don't restyle code that has nothing to do with your PR.
+- New code should follow the tidyverse [style
+  guide](https://style.tidyverse.org). You can use
+  [Air](https://posit-dev.github.io/air/) to apply this style, but please don't
+  restyle code that has nothing to do with your PR.
 
--   We use [roxygen2](https://cran.r-project.org/package=roxygen2), with
-    [Markdown
-    syntax](https://cran.r-project.org/web/packages/roxygen2/vignettes/rd-formatting.html),
-    for documentation.
+- We use [roxygen2](https://cran.r-project.org/package=roxygen2), with [Markdown
+  syntax](https://cran.r-project.org/web/packages/roxygen2/vignettes/rd-formatting.html),
+  for documentation.
 
--   We use [testthat](https://cran.r-project.org/package=testthat) for unit
-    tests. Contributions with test cases included are easier to accept.
+- We use [testthat](https://cran.r-project.org/package=testthat) for unit tests.
+  Contributions with test cases included are easier to accept.
 
-## Thanks for contributing!
+## Code of Conduct
 
-This contributing guide is adapted from the tidyverse contributing guide
-available at <https://tidyverse.tidyverse.org/CONTRIBUTING.html>.
+Please note that the giscoR project is released with a [Contributor Code of
+Conduct](CODE_OF_CONDUCT.md). By contributing to this project you agree to abide
+by its terms.

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,16 @@
+---
+name: Bug report or feature request
+about: Describe a bug you've seen or make a case for a new feature
+---
+
+Please briefly describe your problem and what output you expect. If you have a question, please don't use this form. Instead, ask on <https://stackoverflow.com/> or <https://community.rstudio.com/>.
+
+Please include a minimal reproducible example (AKA a reprex). If you've never heard of a [reprex](http://reprex.tidyverse.org/) before, start by reading <https://www.tidyverse.org/help/#reprex>.
+
+For more advice on how to write a great issue, see <https://code-review.tidyverse.org/issues/>.
+
+Brief description of the problem
+
+```r
+# insert reprex here
+```

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,35 @@
+# Getting help with giscoR
+
+Thanks for using giscoR!
+Before filing an issue, there are a few places to explore and pieces to put together to make the process as smooth as possible.
+
+## Make a reprex
+
+Start by making a minimal **repr**oducible **ex**ample using the  [reprex](https://reprex.tidyverse.org/) package. 
+If you haven't heard of or used reprex before, you're in for a treat! 
+Seriously, reprex will make all of your R-question-asking endeavors easier (which is a pretty incredible ROI for the five to ten minutes it'll take you to learn what it's all about). 
+For additional reprex pointers, check out the [Get help!](https://www.tidyverse.org/help/) section of the tidyverse site.
+
+## Where to ask?
+
+Armed with your reprex, the next step is to figure out [where to ask](https://www.tidyverse.org/help/#where-to-ask). 
+
+*   If it's a question: start with [community.rstudio.com](https://community.rstudio.com/), and/or StackOverflow. There are more people there to answer questions.  
+
+*   If it's a bug: you're in the right place, [file an issue](https://github.com/rOpenGov/giscoR/issues/new).  
+  
+*   If you're not sure: let the community help you figure it out! 
+    If your problem _is_ a bug or a feature request, you can easily return here and report it. 
+
+Before opening a new issue, be sure to [search issues and pull requests](https://github.com/rOpenGov/giscoR/issues) to make sure the bug hasn't been reported and/or already fixed in the development version. 
+By default, the search will be pre-populated with `is:issue is:open`. 
+You can [edit the qualifiers](https://help.github.com/articles/searching-issues-and-pull-requests/)  (e.g. `is:pr`, `is:closed`) as needed. 
+For example, you'd simply remove `is:open` to search _all_ issues in the repo, open or closed.
+
+## What happens next?
+
+To be as efficient as possible, development of tidyverse packages tends to be very bursty, so you shouldn't worry if you don't get an immediate response.
+Typically we don't look at a repo until a sufficient quantity of issues accumulates, then there’s a burst of intense activity as we focus our efforts. 
+That makes development more efficient because it avoids expensive context switching between problems, at the cost of taking longer to get back to you. 
+This process makes a good reprex particularly important because it might be multiple months between your initial report and when we start working on it. 
+If we can’t reproduce the bug, we can’t fix it!

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,7 +55,7 @@ Copyright: The general copyright notice and license policy from Eurostat
 Encoding: UTF-8
 LazyData: true
 X-schema.org-applicationCategory: cartography
-X-schema.org-isPartOf: http://ropengov.org/
+X-schema.org-isPartOf: https://ropengov.org/
 X-schema.org-keywords: ropengov, r, spatial, api-wrapper, rstats,
     r-package, eurostat, gisco, thematic-maps, eurostat-data, cran,
     ggplot2, gis, cran-r

--- a/R/gisco-attributions.R
+++ b/R/gisco-attributions.R
@@ -139,7 +139,8 @@ gisco_attributions <- function(lang = "en", copyright = FALSE) {
     "{.url https://github.com/rOpenGov/giscoR/issues}."
   )
 
-  attr <- switch(lang,
+  attr <- switch(
+    lang,
     "en" = "\u00a9 EuroGeographics for the administrative boundaries",
     "da" = "\u00a9 EuroGeographics for administrative gr\u00e6nser",
     "de" = "\u00a9 EuroGeographics bez\u00fcglich der Verwaltungsgrenzen",

--- a/R/gisco-bulk-download.R
+++ b/R/gisco-bulk-download.R
@@ -210,7 +210,8 @@ bulk_download_api_entry <- function(route) {
 #' @return A character string with the bulk-download alias.
 #' @noRd
 bulk_download_alias <- function(id) {
-  switch(id,
+  switch(
+    id,
     "coastal_lines" = "coastline",
     "urban_audit" = "urau",
     "postal_codes" = "pcode",
@@ -225,10 +226,7 @@ bulk_download_alias <- function(id) {
 #' @return A character string with the cache subdirectory.
 #' @noRd
 bulk_download_subdir <- function(id) {
-  switch(id,
-    "coastal_lines" = "coastal",
-    id
-  )
+  switch(id, "coastal_lines" = "coastal", id)
 }
 
 #' Build a bulk-download ZIP file name

--- a/R/gisco-get-unit-country.R
+++ b/R/gisco-get-unit-country.R
@@ -88,11 +88,7 @@ gisco_get_unit_country <- function(
   # RG: AD-region-01m-3035-2024.geojson
   # LB: AD-label-3035-2024.geojson
 
-  use_code <- switch(year,
-    "2001" = "iso3c",
-    "2006" = "iso2c",
-    "eurostat"
-  )
+  use_code <- switch(year, "2001" = "iso3c", "2006" = "iso2c", "eurostat")
   unit_code <- convert_country_code(unit, use_code)
 
   unit_names <- build_unit_filenames(unit_code, type, epsg, year, res_txt)

--- a/R/utils-country.R
+++ b/R/utils-country.R
@@ -20,10 +20,7 @@ convert_country_code <- function(names, out = "eurostat") {
         "xkx" == tolower(x)
       )
     ) {
-      code <- switch(out,
-        "eurostat" = "XK",
-        "iso3c" = "XKX"
-      )
+      code <- switch(out, "eurostat" = "XK", "iso3c" = "XKX")
       return(code)
     }
 

--- a/R/utils-units.R
+++ b/R/utils-units.R
@@ -25,10 +25,7 @@ build_unit_filenames <- function(unit_code, type, epsg, year, res_txt = NULL) {
 #' @return A character string with GISCO's single-unit file type.
 #' @noRd
 unit_spatialtype_to_file_type <- function(spatialtype) {
-  switch(spatialtype,
-    "RG" = "region",
-    "LB" = "label"
-  )
+  switch(spatialtype, "RG" = "region", "LB" = "label")
 }
 
 #' Read one GISCO single-unit file

--- a/R/utils.R
+++ b/R/utils.R
@@ -22,7 +22,8 @@ make_msg <- function(type = "generic", verbose, ..., .envir = parent.frame()) {
   dots <- list(...)
   msg <- paste(dots, collapse = " ")
 
-  alert <- switch(type,
+  alert <- switch(
+    type,
     generic = cli::cli_alert,
     success = cli::cli_alert_success,
     warning = cli::cli_alert_warning,

--- a/tests/testthat/_snaps/gisco-address-api.md
+++ b/tests/testthat/_snaps/gisco-address-api.md
@@ -7,3 +7,103 @@
       > Returning "NULL".
       ! No results found. Returning "NULL".
 
+# Address API returns NULL for 404 responses
+
+    Code
+      n <- gisco_address_api_bbox()
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/addressapi/bbox>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+      ! No results found. Returning "NULL".
+
+---
+
+    Code
+      n <- gisco_address_api_cities()
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/addressapi/cities>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+
+---
+
+    Code
+      n <- gisco_address_api_copyright()
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/addressapi/copyright>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+
+---
+
+    Code
+      n <- gisco_address_api_housenumbers()
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/addressapi/housenumbers>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+
+---
+
+    Code
+      n <- gisco_address_api_postcodes()
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/addressapi/postcodes>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+
+---
+
+    Code
+      n <- gisco_address_api_provinces()
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/addressapi/provinces>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+
+---
+
+    Code
+      n <- gisco_address_api_reverse(x = 0, y = 0)
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/addressapi/reverse?x=0&y=0>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+
+---
+
+    Code
+      n <- gisco_address_api_roads()
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/addressapi/roads>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+
+---
+
+    Code
+      n <- gisco_address_api_search()
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/addressapi/search>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+
+---
+
+    Code
+      n <- gisco_address_api_countries()
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/addressapi/countries>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+
+---
+
+    Code
+      n <- gisco_address_api_copyright()
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/addressapi/copyright>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+

--- a/tests/testthat/_snaps/gisco-bulk-download.md
+++ b/tests/testthat/_snaps/gisco-bulk-download.md
@@ -1,3 +1,20 @@
+# Bulk download returns NULL when offline
+
+    Code
+      n <- gisco_bulk_download(update_cache = TRUE)
+    Message
+      x No internet connection available.
+      > Returning "NULL".
+
+# Bulk download returns NULL for 404 responses
+
+    Code
+      n <- gisco_bulk_download(update_cache = TRUE)
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/distribution/v2/countries/download/ref-countries-2016-10m.shp.zip>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+
 # Bulk download reports deprecated arguments
 
     Code
@@ -20,6 +37,28 @@
 # Bulk download validates user inputs
 
     Code
+      gisco_bulk_download(year = "2000")
+    Condition
+      Error:
+      ! Years available for `giscoR::gisco_bulk_download()` are 2001, 2006, 2010, 2013, 2016, 2020, and 2024.
+
+---
+
+    Code
+      gisco_bulk_download(resolution = "35")
+    Condition
+      Error:
+      ! No results for `giscoR::gisco_bulk_download()` with these parameters:
+      * `year` = "2016"
+      * `epsg` = "4326"
+      * `resolution` = "35"
+      * `spatialtype` = "RG"
+      * `ext` = "shp"
+      i Check available combinations in `giscoR::gisco_get_cached_db()`.
+
+---
+
+    Code
       gisco_bulk_download(id_giscoR = "nutes")
     Condition
       Warning:
@@ -27,4 +66,12 @@
       i Please use the `id` argument instead.
       Error:
       ! `id` must be "countries", "coastal_lines", "communes", "lau", "nuts", "urban_audit", or "postal_codes", not "nutes".
+
+---
+
+    Code
+      gisco_bulk_download(ext = "aa")
+    Condition
+      Error:
+      ! `ext` must be "shp", "geojson", "svg", "json", or "gdb", not "aa".
 

--- a/tests/testthat/_snaps/gisco-get-airports.md
+++ b/tests/testthat/_snaps/gisco-get-airports.md
@@ -1,0 +1,17 @@
+# Airports return NULL for 404 responses
+
+    Code
+      n <- gisco_get_airports(update_cache = TRUE)
+    Message
+      x Error 404 (Not Found): <https://ec.europa.eu/eurostat/documents/d/gisco/airp-pt-2024-sh>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+
+# Airports download current and legacy point data
+
+    Code
+      gisco_get_airports(year = 2020)
+    Condition
+      Error:
+      ! `year` must be "2024", "2013", or "2006", not "2020".
+

--- a/tests/testthat/_snaps/gisco-get-cached-db.md
+++ b/tests/testthat/_snaps/gisco-get-cached-db.md
@@ -6,6 +6,25 @@
       ! Could not access <https://gisco-services.ec.europa.eu/distribution/v2/>. If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
       > Returning "NULL".
 
+# Cached database returns NULL for 404 responses
+
+    Code
+      n <- gisco_get_cached_db(update_cache = TRUE)
+    Message
+      ! Could not access <https://gisco-services.ec.europa.eu/distribution/v2/>. If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+
+# Cached database stores fallback data when remote access fails
+
+    Code
+      n <- get_db()
+    Message
+      ! Could not access <https://gisco-services.ec.europa.eu/distribution/v2/>. If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+      ! Could not retrieve the latest database from <https://gisco-services.ec.europa.eu/distribution/v2/>.
+      Try again later with `giscoR::gisco_get_cached_db()` and `update_cache` = TRUE.
+      i Using cached "gisco_db" (`?giscoR::gisco_db()`) information as of "2026-06-19". It may be outdated.
+
 # Cached database refreshes from the remote metadata
 
     Code

--- a/tests/testthat/_snaps/gisco-get-census.md
+++ b/tests/testthat/_snaps/gisco-get-census.md
@@ -1,0 +1,22 @@
+# Census returns NULL for 404 responses
+
+    Code
+      n <- gisco_get_census(update_cache = TRUE, spatialtype = "PT")
+    Message
+      Error
+
+# Census reads point geometries
+
+    Code
+      gisco_get_census(year = 2020)
+    Condition
+      Error:
+      ! `year` must be "2011", not "2020".
+
+# Census reads polygon geometries
+
+    Code
+      all <- gisco_get_census(spatialtype = "RG")
+    Message
+      Mocked census polygon read.
+

--- a/tests/testthat/_snaps/gisco-get-coastal-lines.md
+++ b/tests/testthat/_snaps/gisco-get-coastal-lines.md
@@ -13,3 +13,12 @@
     Message
       i Loaded from `?giscoR::gisco_coastal_lines()` dataset. Use `update_cache` = TRUE to reload from file.
 
+# Coastal lines return NULL for 404 responses
+
+    Code
+      n <- gisco_get_coastal_lines(update_cache = TRUE, resolution = 60)
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/distribution/v2/coas/gpkg/COAS_RG_60M_2016_4326.gpkg>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+

--- a/tests/testthat/_snaps/gisco-get-communes.md
+++ b/tests/testthat/_snaps/gisco-get-communes.md
@@ -1,3 +1,72 @@
+# Communes return NULL for 404 responses
+
+    Code
+      n <- gisco_get_communes(update_cache = TRUE, spatialtype = "LB")
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/distribution/v2/communes/shp/COMM_LB_2016_4326.shp.zip>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+
+# Communes validate year, EPSG and spatial type
+
+    Code
+      gisco_get_communes(year = "2007")
+    Condition
+      Error:
+      ! Years available for `giscoR::gisco_get_communes()` are 2001, 2004, 2006, 2008, 2010, 2013, and 2016.
+
+---
+
+    Code
+      gisco_get_communes(epsg = "9999")
+    Condition
+      Error:
+      ! No results for `giscoR::gisco_get_communes()` with these parameters:
+      * `year` = "2016"
+      * `epsg` = "9999"
+      * `spatialtype` = "RG"
+      * `ext` = "shp"
+      i Check available combinations in `giscoR::gisco_get_cached_db()`.
+
+---
+
+    Code
+      gisco_get_communes(year = "2004", spatialtype = "COASTL")
+    Condition
+      Error:
+      ! No results for `giscoR::gisco_get_communes()` with these parameters:
+      * `year` = "2004"
+      * `epsg` = "4326"
+      * `spatialtype` = "COASTL"
+      * `ext` = "shp"
+      i Check available combinations in `giscoR::gisco_get_cached_db()`.
+
+---
+
+    Code
+      gisco_get_communes(year = "2004", spatialtype = "INLAND")
+    Condition
+      Error:
+      ! No results for `giscoR::gisco_get_communes()` with these parameters:
+      * `year` = "2004"
+      * `epsg` = "4326"
+      * `spatialtype` = "INLAND"
+      * `ext` = "shp"
+      i Check available combinations in `giscoR::gisco_get_cached_db()`.
+
+---
+
+    Code
+      gisco_get_communes(spatialtype = "ERR")
+    Condition
+      Error:
+      ! No results for `giscoR::gisco_get_communes()` with these parameters:
+      * `year` = "2016"
+      * `epsg` = "4326"
+      * `spatialtype` = "ERR"
+      * `ext` = "shp"
+      i Check available combinations in `giscoR::gisco_get_cached_db()`.
+
 # Communes report deprecated cache usage
 
     Code

--- a/tests/testthat/_snaps/gisco-get-countries.md
+++ b/tests/testthat/_snaps/gisco-get-countries.md
@@ -13,3 +13,12 @@
       Error:
       ! `ext` must be "geojson", "gpkg", or "shp", not "docx".
 
+# Countries return NULL for 404 responses
+
+    Code
+      n <- gisco_get_countries(update_cache = TRUE, resolution = 60)
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/distribution/v2/countries/gpkg/CNTR_RG_60M_2024_4326.gpkg>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+

--- a/tests/testthat/_snaps/gisco-get-education.md
+++ b/tests/testthat/_snaps/gisco-get-education.md
@@ -1,0 +1,41 @@
+# Education returns NULL for 404 responses
+
+    Code
+      n <- gisco_get_education(country = "LU", update_cache = TRUE)
+    Message
+      Error
+
+# Education reads mocked 2023 service data
+
+    Code
+      gisco_get_education(verbose = TRUE, country = "BE")
+    Message
+      Mocked education read.
+    Output
+      Simple feature collection with 1 feature and 1 field
+      Geometry type: POINT
+      Dimension:     XY
+      Bounding box:  xmin: 1 ymin: 1 xmax: 1 ymax: 1
+      Geodetic CRS:  WGS 84
+      # A tibble: 1 x 2
+        cntr_id    geometry
+      * <chr>   <POINT [°]>
+      1 BE            (1 1)
+
+# Education reads mocked 2020 service data
+
+    Code
+      gisco_get_education(verbose = TRUE, country = "BE", year = 2020)
+    Message
+      Mocked education 2020 read.
+    Output
+      Simple feature collection with 1 feature and 1 field
+      Geometry type: POINT
+      Dimension:     XY
+      Bounding box:  xmin: 1 ymin: 1 xmax: 1 ymax: 1
+      Geodetic CRS:  WGS 84
+      # A tibble: 1 x 2
+        cntr_id    geometry
+      * <chr>   <POINT [°]>
+      1 BE            (1 1)
+

--- a/tests/testthat/_snaps/gisco-get-grid.md
+++ b/tests/testthat/_snaps/gisco-get-grid.md
@@ -1,0 +1,25 @@
+# Grid validates inputs
+
+    Code
+      gisco_get_grid(resolution = 24)
+    Condition
+      Error:
+      ! `resolution` must be "100", "50", "20", "10", "5", "2", or "1", not "24".
+
+---
+
+    Code
+      gisco_get_grid(spatialtype = "9999")
+    Condition
+      Error:
+      ! `spatialtype` must be "REGION" or "POINT", not "9999".
+
+# Grids return NULL for 404 responses
+
+    Code
+      n <- gisco_get_grid(update_cache = TRUE)
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/grid/grid_100km_surf.gpkg>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+

--- a/tests/testthat/_snaps/gisco-get-healthcare.md
+++ b/tests/testthat/_snaps/gisco-get-healthcare.md
@@ -1,0 +1,27 @@
+# Healthcare returns NULL for 404 responses
+
+    Code
+      n <- gisco_get_healthcare(update_cache = TRUE, year = 2020)
+    Message
+      Error
+
+# Healthcare reads, filters and caches mocked data
+
+    Code
+      gisco_get_healthcare(verbose = TRUE)
+    Message
+      Mocked healthcare read.
+    Output
+      Simple feature collection with 4 features and 1 field
+      Geometry type: POINT
+      Dimension:     XY
+      Bounding box:  xmin: 1 ymin: 1 xmax: 4 ymax: 4
+      Geodetic CRS:  WGS 84
+      # A tibble: 4 x 2
+        cntr_id    geometry
+        <chr>   <POINT [°]>
+      1 LU            (1 1)
+      2 ES            (2 2)
+      3 BE            (3 3)
+      4 ES            (4 4)
+

--- a/tests/testthat/_snaps/gisco-get-lau.md
+++ b/tests/testthat/_snaps/gisco-get-lau.md
@@ -1,3 +1,33 @@
+# LAU returns NULL for 404 responses
+
+    Code
+      n <- gisco_get_lau(update_cache = TRUE, year = 2020)
+    Message
+      ! The file to download is "61.9 Mb".
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/distribution/v2/lau/gpkg/LAU_RG_01M_2020_4326.gpkg>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+
+# LAU validates year and EPSG
+
+    Code
+      gisco_get_lau(year = "2001")
+    Condition
+      Error:
+      ! Years available for `giscoR::gisco_get_lau()` are 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, and 2024.
+
+---
+
+    Code
+      gisco_get_lau(epsg = "9999")
+    Condition
+      Error:
+      ! No results for `giscoR::gisco_get_lau()` with these parameters:
+      * `year` = "2024"
+      * `epsg` = "9999"
+      * `ext` = "gpkg"
+      i Check available combinations in `giscoR::gisco_get_cached_db()`.
+
 # LAU reports deprecated cache usage
 
     Code

--- a/tests/testthat/_snaps/gisco-get-metadata.md
+++ b/tests/testthat/_snaps/gisco-get-metadata.md
@@ -6,6 +6,15 @@
       x No internet connection available.
       > Returning "NULL".
 
+# Metadata returns NULL for 404 responses
+
+    Code
+      n <- gisco_get_metadata()
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/distribution/v2/nuts/csv/NUTS_AT_2024.csv>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+
 # Metadata validates dataset and year inputs
 
     Code

--- a/tests/testthat/_snaps/gisco-get-nuts.md
+++ b/tests/testthat/_snaps/gisco-get-nuts.md
@@ -21,3 +21,20 @@
     Message
       i Loaded from `?giscoR::gisco_nuts_2024()` dataset. Use `update_cache` = TRUE to reload from file.
 
+# NUTS return NULL when offline
+
+    Code
+      n <- gisco_get_nuts(update_cache = TRUE, cache_dir = cdir, resolution = 60)
+    Message
+      x No internet connection available.
+      > Returning "NULL".
+
+# NUTS return NULL for 404 responses
+
+    Code
+      n <- gisco_get_nuts(update_cache = TRUE, resolution = 60)
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/distribution/v2/nuts/gpkg/NUTS_RG_60M_2024_4326.gpkg>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+

--- a/tests/testthat/_snaps/gisco-get-ports.md
+++ b/tests/testthat/_snaps/gisco-get-ports.md
@@ -1,0 +1,25 @@
+# Ports return NULL for 404 responses
+
+    Code
+      n <- gisco_get_ports(update_cache = TRUE)
+    Message
+      x Error 404 (Not Found): <https://ec.europa.eu/eurostat/cache/GISCO/geodatafiles/PORT_2013_SH.zip>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+
+# Ports download current and legacy point data
+
+    Code
+      gisco_get_ports(year = 2020)
+    Condition
+      Error:
+      ! `year` must be "2013" or "2009", not "2020".
+
+---
+
+    Code
+      gisco_get_ports(year = 2020, country = "ES")
+    Condition
+      Error:
+      ! `year` must be "2013" or "2009", not "2020".
+

--- a/tests/testthat/_snaps/gisco-get-postal-codes.md
+++ b/tests/testthat/_snaps/gisco-get-postal-codes.md
@@ -1,3 +1,21 @@
+# Postal codes validate available years
+
+    Code
+      gisco_get_postal_codes("1991", "Years available for")
+    Condition
+      Error:
+      ! Years available for `giscoR::gisco_get_postal_codes()` are 2020, 2024, and 2025.
+
+# Postal codes return NULL for 404 responses
+
+    Code
+      n <- gisco_get_postal_codes(year = 2024, country = "ES", update_cache = TRUE)
+    Message
+      ! The file to download is "196.9 Mb".
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/distribution/v2/pcode/gpkg/PCODE_PT_2024_4326.gpkg>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+
 # Postal codes reject unsupported extensions and read shapefiles
 
     Code

--- a/tests/testthat/_snaps/gisco-get-unit-country.md
+++ b/tests/testthat/_snaps/gisco-get-unit-country.md
@@ -30,3 +30,24 @@
       Error:
       ! `spatialtype` must be "RG" or "LB", not "foo".
 
+# Country unit returns NULL when offline
+
+    Code
+      n <- gisco_get_unit_country(year = 2024, unit = "ES", update_cache = TRUE,
+        verbose = TRUE)
+    Message
+      i Requested file 'ES-region-01m-4326-2024.geojson'.
+      x No internet connection available.
+      > Returning "NULL".
+
+# Country unit returns NULL for 404 responses
+
+    Code
+      n <- gisco_get_unit_country(year = 2024, unit = "ES", update_cache = TRUE,
+        verbose = TRUE)
+    Message
+      i Requested file 'ES-region-01m-4326-2024.geojson'.
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/distribution/v2/countries/countries-2024-units.json>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+

--- a/tests/testthat/_snaps/gisco-get-unit-nuts.md
+++ b/tests/testthat/_snaps/gisco-get-unit-nuts.md
@@ -30,3 +30,22 @@
       Error:
       ! `spatialtype` must be "RG" or "LB", not "foo".
 
+# NUTS unit returns NULL when offline
+
+    Code
+      n <- gisco_get_unit_nuts(year = 2024, update_cache = TRUE, verbose = TRUE)
+    Message
+      i Requested file 'ES416-region-01m-4326-2024.geojson'.
+      x No internet connection available.
+      > Returning "NULL".
+
+# NUTS unit returns NULL for 404 responses
+
+    Code
+      n <- gisco_get_unit_nuts(year = 2024, update_cache = TRUE, verbose = TRUE)
+    Message
+      i Requested file 'ES416-region-01m-4326-2024.geojson'.
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/distribution/v2/nuts/nuts-2024-units.json>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+

--- a/tests/testthat/_snaps/gisco-get-unit-urban-audit.md
+++ b/tests/testthat/_snaps/gisco-get-unit-urban-audit.md
@@ -22,3 +22,22 @@
       Error:
       ! `spatialtype` must be "RG" or "LB", not "foo".
 
+# Urban audit unit returns NULL when offline
+
+    Code
+      n <- gisco_get_unit_urban_audit(year = 2024, update_cache = TRUE, verbose = TRUE)
+    Message
+      i Requested file 'ES001F-region-100k-4326-2024.geojson'.
+      x No internet connection available.
+      > Returning "NULL".
+
+# Urban audit unit returns NULL for 404 responses
+
+    Code
+      n <- gisco_get_unit_urban_audit(year = 2024, update_cache = TRUE, verbose = TRUE)
+    Message
+      i Requested file 'ES001F-region-100k-4326-2024.geojson'.
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/distribution/v2/urau/urau-2024-units.json>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+

--- a/tests/testthat/_snaps/gisco-get-urban-audit.md
+++ b/tests/testthat/_snaps/gisco-get-urban-audit.md
@@ -1,3 +1,64 @@
+# Urban audit validates inputs before remote access
+
+    Code
+      gisco_get_urban_audit(year = "1999")
+    Condition
+      Error:
+      ! Years available for `giscoR::gisco_get_urban_audit()` are 2001, 2004, 2014, 2018, 2020, 2021, and 2024.
+
+---
+
+    Code
+      gisco_get_urban_audit(epsg = "9999")
+    Condition
+      Error:
+      ! No results for `giscoR::gisco_get_urban_audit()` with these parameters:
+      * `year` = "2024"
+      * `epsg` = "9999"
+      * `spatialtype` = "RG"
+      * `level` = "all"
+      * `ext` = "gpkg"
+      i Check available combinations in `giscoR::gisco_get_cached_db()`.
+
+---
+
+    Code
+      gisco_get_urban_audit(level = "9999")
+    Condition
+      Error:
+      ! `level` must be "all", "CITIES", "FUA", "GREATER_CITIES", "CITY", "KERN", or "LUZ", not "9999".
+
+---
+
+    Code
+      gisco_get_urban_audit(spatialtype = "BN")
+    Condition
+      Error:
+      ! `spatialtype` must be "RG" or "LB", not "BN".
+
+---
+
+    Code
+      gisco_get_urban_audit(year = 2001)
+    Condition
+      Error:
+      ! No results for `giscoR::gisco_get_urban_audit()` with these parameters:
+      * `year` = "2001"
+      * `epsg` = "4326"
+      * `spatialtype` = "RG"
+      * `level` = "all"
+      * `ext` = "gpkg"
+      i Check available combinations in `giscoR::gisco_get_cached_db()`.
+
+# Urban audit returns NULL for 404 responses
+
+    Code
+      n <- gisco_get_urban_audit(update_cache = TRUE)
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/distribution/v2/urau/gpkg/URAU_RG_100K_2024_4326.gpkg>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+
 # Urban audit validates extensions and level inputs
 
     Code

--- a/tests/testthat/_snaps/gisco-id-api.md
+++ b/tests/testthat/_snaps/gisco-id-api.md
@@ -14,6 +14,42 @@
       x No internet connection available.
       > Returning "NULL".
 
+# ID API returns NULL for 404 responses
+
+    Code
+      n <- gisco_id_api_geonames(x = 4, y = 52)
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/id/geonames?x=4&y=52>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+
+---
+
+    Code
+      n <- gisco_id_api_nuts(x = 4, y = 52, geometry = TRUE)
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/id/nuts?x=4&y=52&epsg=4326&year=2024&format=geojson&geometry=yes>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+
+---
+
+    Code
+      n <- gisco_id_api_lau(x = 4, y = 52, geometry = TRUE)
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/id/lau?x=4&y=52&epsg=4326&year=2024&format=geojson&geometry=yes>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+
+---
+
+    Code
+      n <- gisco_id_api_country(x = 4, y = 52, geometry = FALSE)
+    Message
+      x Error 404 (Not Found): <https://gisco-services.ec.europa.eu/id/country?x=4&y=52&epsg=4326&year=2024&format=json&geometry=no>.
+      ! If this looks like a bug, please open an issue at <https://github.com/ropengov/giscoR/issues>.
+      > Returning "NULL".
+
 # gisco_id_api_nuts online
 
     Code

--- a/tests/testthat/_snaps/utils-url.md
+++ b/tests/testthat/_snaps/utils-url.md
@@ -10,6 +10,14 @@
 # URL database lookup validates and returns matching entries
 
     Code
+      get_url_db("postal_codes", year = "1991", fn = "gisco_get_postalcodes")
+    Condition
+      Error:
+      ! Years available for `giscoR::gisco_get_postalcodes()` are 2020, 2024, and 2025.
+
+---
+
+    Code
       get_url_db("communes", "9999", fn = "gisco_get_communes")
     Condition
       Error:

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -131,3 +131,51 @@
       Error in `test_msg()`:
       ! `verbose` must be a <logical>.
 
+# Argument matching reports invalid values
+
+    Code
+      match_year(2030)
+    Condition
+      Error:
+      ! `year` must be "2020" or "2024", not "2030".
+
+---
+
+    Code
+      match_year(c(2020, 2030))
+    Condition
+      Error:
+      ! `year` must be "2020" or "2024", not "2020" or "2030".
+
+# rbind_fill combines sf inputs with different schemas
+
+    Code
+      err <- do.call(rbind, a_list)
+    Condition
+      Error in `rbind.data.frame()`:
+      ! numbers of columns of arguments do not match
+
+# rbind_fill combines tibble inputs with different schemas
+
+    Code
+      err <- do.call(rbind, a_list)
+    Condition
+      Error in `rbind()`:
+      ! numbers of columns of arguments do not match
+
+# rbind_fill drops NULL entries from sf input lists
+
+    Code
+      err <- do.call(rbind, a_list)
+    Condition
+      Error in `rbind.data.frame()`:
+      ! numbers of columns of arguments do not match
+
+# rbind_fill drops NULL entries from tibble input lists
+
+    Code
+      err <- do.call(rbind, a_list)
+    Condition
+      Error in `rbind()`:
+      ! numbers of columns of arguments do not match
+

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -8,11 +8,26 @@ skip_if_gisco_offline <- function() {
   invisible()
 }
 
-local_test_cache_dir <- function(pattern = "gisco-test-") {
-  path <- withr::local_tempdir(pattern = pattern, .local_envir = parent.frame())
+local_test_cache_dir <- function(
+  pattern = "gisco-test-",
+  .local_envir = parent.frame()
+) {
+  path <- withr::local_tempdir(pattern = pattern, .local_envir = .local_envir)
   withr::defer(
     unlink(path, recursive = TRUE, force = TRUE),
-    envir = parent.frame()
+    envir = .local_envir
   )
   path
+}
+
+local_test_cached_db <- function(pattern = "gisco-db-") {
+  local_envir <- parent.frame()
+  cache_dir <- local_test_cache_dir(pattern, .local_envir = local_envir)
+  withr::local_envvar(
+    GISCO_CACHE_DIR = cache_dir,
+    .local_envir = local_envir
+  )
+
+  saveRDS(giscoR::gisco_db, cached_db_file(cache_dir))
+  invisible(cache_dir)
 }

--- a/tests/testthat/test-gisco-address-api.R
+++ b/tests/testthat/test-gisco-address-api.R
@@ -16,36 +16,36 @@ test_that("Address API returns NULL for 404 responses", {
   local_mocked_bindings(is_404 = function(...) {
     TRUE
   })
-  expect_message(n <- gisco_address_api_bbox(), "Error")
+  expect_snapshot(n <- gisco_address_api_bbox())
   expect_null(n)
 
-  expect_message(n <- gisco_address_api_cities(), "Error")
+  expect_snapshot(n <- gisco_address_api_cities())
 
-  expect_message(n <- gisco_address_api_copyright(), "Error")
+  expect_snapshot(n <- gisco_address_api_copyright())
   expect_null(n)
 
-  expect_message(n <- gisco_address_api_housenumbers(), "Error")
+  expect_snapshot(n <- gisco_address_api_housenumbers())
   expect_null(n)
 
-  expect_message(n <- gisco_address_api_postcodes(), "Error")
+  expect_snapshot(n <- gisco_address_api_postcodes())
   expect_null(n)
 
-  expect_message(n <- gisco_address_api_provinces(), "Error")
+  expect_snapshot(n <- gisco_address_api_provinces())
   expect_null(n)
 
-  expect_message(n <- gisco_address_api_reverse(x = 0, y = 0), "Error")
+  expect_snapshot(n <- gisco_address_api_reverse(x = 0, y = 0))
   expect_null(n)
 
-  expect_message(n <- gisco_address_api_roads(), "Error")
+  expect_snapshot(n <- gisco_address_api_roads())
   expect_null(n)
 
-  expect_message(n <- gisco_address_api_search(), "Error")
+  expect_snapshot(n <- gisco_address_api_search())
   expect_null(n)
 
-  expect_message(n <- gisco_address_api_countries(), "Error")
+  expect_snapshot(n <- gisco_address_api_countries())
   expect_null(n)
 
-  expect_message(n <- gisco_address_api_copyright(), "Error")
+  expect_snapshot(n <- gisco_address_api_copyright())
   expect_null(n)
 })
 

--- a/tests/testthat/test-gisco-bulk-download.R
+++ b/tests/testthat/test-gisco-bulk-download.R
@@ -1,22 +1,24 @@
 test_that("Bulk download returns NULL when offline", {
   skip_on_cran()
   skip_if_gisco_offline()
+  local_test_cached_db("bulk-db-")
 
   local_mocked_bindings(is_online_fun = function(...) {
     FALSE
   })
-  expect_message(n <- gisco_bulk_download(update_cache = TRUE), "No internet")
+  expect_snapshot(n <- gisco_bulk_download(update_cache = TRUE))
   expect_null(n)
 })
 
 test_that("Bulk download returns NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
+  local_test_cached_db("bulk-db-")
 
   local_mocked_bindings(is_404 = function(...) {
     TRUE
   })
-  expect_message(n <- gisco_bulk_download(update_cache = TRUE), "Error")
+  expect_snapshot(n <- gisco_bulk_download(update_cache = TRUE))
   expect_null(n)
 })
 
@@ -91,12 +93,14 @@ test_that("Bulk download orchestrates download and extraction", {
         "countries/shp/CNTR_RG_60M_2024_4326.shp.zip"
       )
     },
-    download_url = function(url,
-                            name,
-                            cache_dir,
-                            subdir,
-                            update_cache = FALSE,
-                            verbose = FALSE) {
+    download_url = function(
+      url,
+      name,
+      cache_dir,
+      subdir,
+      update_cache = FALSE,
+      verbose = FALSE
+    ) {
       expect_match(url, "countries/download/ref-countries-2024-60m.geojson.zip")
       expect_identical(name, "ref-countries-2024-60m.geojson.zip")
       expect_identical(cache_dir, cdir)
@@ -131,10 +135,10 @@ test_that("Bulk download validates user inputs", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  expect_error(gisco_bulk_download(year = "2000"), "Years available")
-  expect_error(gisco_bulk_download(resolution = "35"), "No results")
+  expect_snapshot(gisco_bulk_download(year = "2000"), error = TRUE)
+  expect_snapshot(gisco_bulk_download(resolution = "35"), error = TRUE)
   expect_snapshot(gisco_bulk_download(id_giscoR = "nutes"), error = TRUE)
-  expect_error(gisco_bulk_download(ext = "aa"), "`ext` must be")
+  expect_snapshot(gisco_bulk_download(ext = "aa"), error = TRUE)
 })
 
 test_that("Bulk download builds recursive downloads from mocked metadata", {

--- a/tests/testthat/test-gisco-get-airports.R
+++ b/tests/testthat/test-gisco-get-airports.R
@@ -5,7 +5,7 @@ test_that("Airports return NULL for 404 responses", {
   local_mocked_bindings(is_404 = function(...) {
     TRUE
   })
-  expect_message(n <- gisco_get_airports(update_cache = TRUE), "Error")
+  expect_snapshot(n <- gisco_get_airports(update_cache = TRUE))
   expect_null(n)
 })
 
@@ -49,7 +49,7 @@ test_that("Airports select the 2006 file", {
 })
 
 test_that("Airports download current and legacy point data", {
-  expect_error(gisco_get_airports(year = 2020), "`year` must be")
+  expect_snapshot(gisco_get_airports(year = 2020), error = TRUE)
 
   skip_on_cran()
   skip_if_gisco_offline()

--- a/tests/testthat/test-gisco-get-cached-db.R
+++ b/tests/testthat/test-gisco-get-cached-db.R
@@ -19,10 +19,7 @@ test_that("Cached database returns NULL for 404 responses", {
   local_mocked_bindings(is_404 = function(...) {
     TRUE
   })
-  expect_message(
-    n <- gisco_get_cached_db(update_cache = TRUE),
-    "Could not access"
-  )
+  expect_snapshot(n <- gisco_get_cached_db(update_cache = TRUE))
   expect_null(n)
 })
 
@@ -40,7 +37,7 @@ test_that("Cached database stores fallback data when remote access fails", {
   local_mocked_bindings(is_404 = function(...) {
     TRUE
   })
-  expect_message(n <- get_db(), "Could not access")
+  expect_snapshot(n <- get_db())
   old_db <- gisco_db
   expect_identical(n, old_db)
 

--- a/tests/testthat/test-gisco-get-census.R
+++ b/tests/testthat/test-gisco-get-census.R
@@ -8,9 +8,8 @@ test_that("Census returns NULL for 404 responses", {
       NULL
     }
   )
-  expect_message(
-    n <- gisco_get_census(update_cache = TRUE, spatialtype = "PT"),
-    "Error"
+  expect_snapshot(
+    n <- gisco_get_census(update_cache = TRUE, spatialtype = "PT")
   )
   expect_null(n)
 })
@@ -53,7 +52,7 @@ test_that("Census selects the point file", {
 })
 
 test_that("Census reads point geometries", {
-  expect_error(gisco_get_census(year = 2020), "`year` must be")
+  expect_snapshot(gisco_get_census(year = 2020), error = TRUE)
 
   local_mocked_bindings(read_gisco_dataset = function(
     url,
@@ -100,10 +99,7 @@ test_that("Census reads polygon geometries", {
   })
 
   # On read should warn
-  expect_message(
-    all <- gisco_get_census(spatialtype = "RG"),
-    "Mocked census polygon read"
-  )
+  expect_snapshot(all <- gisco_get_census(spatialtype = "RG"))
   expect_s3_class(all, "tbl_df")
   expect_s3_class(all, "sf")
   expect_true(unique(sf::st_geometry_type(all)) == "MULTIPOLYGON")

--- a/tests/testthat/test-gisco-get-coastal-lines.R
+++ b/tests/testthat/test-gisco-get-coastal-lines.R
@@ -1,13 +1,13 @@
 test_that("Coastal lines return NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
+  local_test_cached_db("coastal-db-")
 
   local_mocked_bindings(is_404 = function(...) {
     TRUE
   })
-  expect_message(
-    n <- gisco_get_coastal_lines(update_cache = TRUE, resolution = 60),
-    "Error"
+  expect_snapshot(
+    n <- gisco_get_coastal_lines(update_cache = TRUE, resolution = 60)
   )
   expect_null(n)
 })
@@ -21,14 +21,16 @@ test_that("Coastal lines use resolved GISCO files", {
       )
     },
     read_packaged_gisco_dataset = function(...) NULL,
-    read_gisco_dataset = function(url,
-                                  name,
-                                  cache = TRUE,
-                                  cache_dir = NULL,
-                                  subdir,
-                                  update_cache = FALSE,
-                                  verbose = FALSE,
-                                  ...) {
+    read_gisco_dataset = function(
+      url,
+      name,
+      cache = TRUE,
+      cache_dir = NULL,
+      subdir,
+      update_cache = FALSE,
+      verbose = FALSE,
+      ...
+    ) {
       expect_match(url, "COAS_RG_20M_2016_4326[.]gpkg$")
       expect_identical(name, "COAS_RG_20M_2016_4326.gpkg")
       expect_false(cache)

--- a/tests/testthat/test-gisco-get-communes.R
+++ b/tests/testthat/test-gisco-get-communes.R
@@ -1,13 +1,13 @@
 test_that("Communes return NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
+  local_test_cached_db("communes-db-")
 
   local_mocked_bindings(is_404 = function(...) {
     TRUE
   })
-  expect_message(
-    n <- gisco_get_communes(update_cache = TRUE, spatialtype = "LB"),
-    "Error"
+  expect_snapshot(
+    n <- gisco_get_communes(update_cache = TRUE, spatialtype = "LB")
   )
   expect_null(n)
 })
@@ -20,15 +20,17 @@ test_that("Communes use resolved GISCO files", {
         name = "COMM_RG_2016_4326.shp.zip"
       )
     },
-    read_gisco_dataset = function(url,
-                                  name,
-                                  cache = TRUE,
-                                  cache_dir = NULL,
-                                  subdir,
-                                  update_cache = FALSE,
-                                  verbose = FALSE,
-                                  filters = NULL,
-                                  ...) {
+    read_gisco_dataset = function(
+      url,
+      name,
+      cache = TRUE,
+      cache_dir = NULL,
+      subdir,
+      update_cache = FALSE,
+      verbose = FALSE,
+      filters = NULL,
+      ...
+    ) {
       expect_match(url, "COMM_RG_2016_4326[.]shp[.]zip$")
       expect_identical(name, "COMM_RG_2016_4326.shp.zip")
       expect_true(cache)
@@ -54,17 +56,17 @@ test_that("Communes validate year, EPSG and spatial type", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  expect_error(gisco_get_communes(year = "2007"), "Years available")
-  expect_error(gisco_get_communes(epsg = "9999"), "No results")
-  expect_error(
+  expect_snapshot(gisco_get_communes(year = "2007"), error = TRUE)
+  expect_snapshot(gisco_get_communes(epsg = "9999"), error = TRUE)
+  expect_snapshot(
     gisco_get_communes(year = "2004", spatialtype = "COASTL"),
-    "No results"
+    error = TRUE
   )
-  expect_error(
+  expect_snapshot(
     gisco_get_communes(year = "2004", spatialtype = "INLAND"),
-    "No results"
+    error = TRUE
   )
-  expect_error(gisco_get_communes(spatialtype = "ERR"), "No results")
+  expect_snapshot(gisco_get_communes(spatialtype = "ERR"), error = TRUE)
 })
 
 test_that("Communes pass country filters to the reader", {
@@ -80,9 +82,11 @@ test_that("Communes pass country filters to the reader", {
     convert_country_code_or_null = function(country) {
       country
     },
-    make_sf_filter = function(file_local,
-                              values,
-                              candidates = c("CNTR_ID", "CNTR_CODE")) {
+    make_sf_filter = function(
+      file_local,
+      values,
+      candidates = c("CNTR_ID", "CNTR_CODE")
+    ) {
       filter_calls[[length(filter_calls) + 1L]] <<- list(
         file_local = file_local,
         values = values,
@@ -90,11 +94,13 @@ test_that("Communes pass country filters to the reader", {
       )
       stats::setNames(list(values), paste(candidates, collapse = "|"))
     },
-    read_gisco_dataset = function(url,
-                                  name,
-                                  filters = NULL,
-                                  verbose = FALSE,
-                                  ...) {
+    read_gisco_dataset = function(
+      url,
+      name,
+      filters = NULL,
+      verbose = FALSE,
+      ...
+    ) {
       expect_match(url, "COMM_LB_2016_4326[.]gpkg$")
       expect_true(is.function(filters))
       expect_true(verbose)

--- a/tests/testthat/test-gisco-get-countries.R
+++ b/tests/testthat/test-gisco-get-countries.R
@@ -1,13 +1,13 @@
 test_that("Countries return NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
+  local_test_cached_db("countries-db-")
 
   local_mocked_bindings(is_404 = function(...) {
     TRUE
   })
-  expect_message(
-    n <- gisco_get_countries(update_cache = TRUE, resolution = 60),
-    "Error"
+  expect_snapshot(
+    n <- gisco_get_countries(update_cache = TRUE, resolution = 60)
   )
   expect_null(n)
 })
@@ -20,16 +20,18 @@ test_that("Countries use resolved GISCO files", {
         name = "CNTR_RG_60M_2024_4326.gpkg"
       )
     },
-    read_gisco_dataset = function(url,
-                                  name,
-                                  cache = TRUE,
-                                  cache_dir = NULL,
-                                  subdir,
-                                  update_cache = FALSE,
-                                  verbose = FALSE,
-                                  filters = NULL,
-                                  post_process = NULL,
-                                  ...) {
+    read_gisco_dataset = function(
+      url,
+      name,
+      cache = TRUE,
+      cache_dir = NULL,
+      subdir,
+      update_cache = FALSE,
+      verbose = FALSE,
+      filters = NULL,
+      post_process = NULL,
+      ...
+    ) {
       expect_match(url, "CNTR_RG_60M_2024_4326[.]gpkg$")
       expect_identical(name, "CNTR_RG_60M_2024_4326.gpkg")
       expect_false(cache)

--- a/tests/testthat/test-gisco-get-education.R
+++ b/tests/testthat/test-gisco-get-education.R
@@ -8,10 +8,7 @@ test_that("Education returns NULL for 404 responses", {
       NULL
     }
   )
-  expect_message(
-    n <- gisco_get_education(country = "LU", update_cache = TRUE),
-    "Error"
-  )
+  expect_snapshot(n <- gisco_get_education(country = "LU", update_cache = TRUE))
   expect_null(n)
 })
 
@@ -89,7 +86,7 @@ test_that("Education reads mocked 2023 service data", {
 
   expect_silent(gisco_get_education(country = "LU", cache = FALSE))
   expect_silent(gisco_get_education(country = "Denmark"))
-  expect_message(gisco_get_education(verbose = TRUE, country = "BE"))
+  expect_snapshot(gisco_get_education(verbose = TRUE, country = "BE"))
 
   # Several countries
   nn <- gisco_get_education(country = c("LU", "DK", "BE"))
@@ -129,7 +126,7 @@ test_that("Education reads mocked 2020 service data", {
 
   expect_silent(gisco_get_education(country = "LU", cache = FALSE, year = 2020))
   expect_silent(gisco_get_education(country = "Denmark", year = 2020))
-  expect_message(gisco_get_education(
+  expect_snapshot(gisco_get_education(
     verbose = TRUE,
     country = "BE",
     year = 2020

--- a/tests/testthat/test-gisco-get-grid.R
+++ b/tests/testthat/test-gisco-get-grid.R
@@ -1,6 +1,6 @@
 test_that("Grid validates inputs", {
-  expect_error(gisco_get_grid(resolution = 24), "`resolution` must be")
-  expect_error(gisco_get_grid(spatialtype = "9999"), "`spatialtype` must be")
+  expect_snapshot(gisco_get_grid(resolution = 24), error = TRUE)
+  expect_snapshot(gisco_get_grid(spatialtype = "9999"), error = TRUE)
 })
 
 test_that("Grids use the grid dataset reader", {
@@ -49,6 +49,6 @@ test_that("Grids return NULL for 404 responses", {
   local_mocked_bindings(is_404 = function(...) {
     TRUE
   })
-  expect_message(n <- gisco_get_grid(update_cache = TRUE), "Error")
+  expect_snapshot(n <- gisco_get_grid(update_cache = TRUE))
   expect_null(n)
 })

--- a/tests/testthat/test-gisco-get-healthcare.R
+++ b/tests/testthat/test-gisco-get-healthcare.R
@@ -8,10 +8,7 @@ test_that("Healthcare returns NULL for 404 responses", {
       NULL
     }
   )
-  expect_message(
-    n <- gisco_get_healthcare(update_cache = TRUE, year = 2020),
-    "Error"
-  )
+  expect_snapshot(n <- gisco_get_healthcare(update_cache = TRUE, year = 2020))
   expect_null(n)
 })
 
@@ -119,5 +116,5 @@ test_that("Healthcare reads, filters and caches mocked data", {
   )
   expect_lt(nrow(esp), nrow(n))
 
-  expect_message(gisco_get_healthcare(verbose = TRUE), "Mocked healthcare read")
+  expect_snapshot(gisco_get_healthcare(verbose = TRUE))
 })

--- a/tests/testthat/test-gisco-get-lau.R
+++ b/tests/testthat/test-gisco-get-lau.R
@@ -1,11 +1,12 @@
 test_that("LAU returns NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
+  local_test_cached_db("lau-db-")
 
   local_mocked_bindings(is_404 = function(...) {
     TRUE
   })
-  expect_message(n <- gisco_get_lau(update_cache = TRUE, year = 2020), "Error")
+  expect_snapshot(n <- gisco_get_lau(update_cache = TRUE, year = 2020))
   expect_null(n)
 })
 
@@ -17,16 +18,18 @@ test_that("LAU use resolved GISCO files", {
         name = "LAU_RG_2024_4326.gpkg"
       )
     },
-    read_gisco_dataset = function(url,
-                                  name,
-                                  cache = TRUE,
-                                  cache_dir = NULL,
-                                  subdir,
-                                  update_cache = FALSE,
-                                  verbose = FALSE,
-                                  filters = NULL,
-                                  operator = "AND",
-                                  ...) {
+    read_gisco_dataset = function(
+      url,
+      name,
+      cache = TRUE,
+      cache_dir = NULL,
+      subdir,
+      update_cache = FALSE,
+      verbose = FALSE,
+      filters = NULL,
+      operator = "AND",
+      ...
+    ) {
       expect_match(url, "LAU_RG_2024_4326[.]gpkg$")
       expect_identical(name, "LAU_RG_2024_4326.gpkg")
       expect_true(cache)
@@ -53,8 +56,8 @@ test_that("LAU validates year and EPSG", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  expect_error(gisco_get_lau(year = "2001"), "Years available")
-  expect_error(gisco_get_lau(epsg = "9999"), "No results")
+  expect_snapshot(gisco_get_lau(year = "2001"), error = TRUE)
+  expect_snapshot(gisco_get_lau(epsg = "9999"), error = TRUE)
 })
 
 test_that("LAU combines country and GISCO ID filters", {
@@ -70,9 +73,11 @@ test_that("LAU combines country and GISCO ID filters", {
     convert_country_code_or_null = function(country) {
       country
     },
-    make_sf_filter = function(file_local,
-                              values,
-                              candidates = c("CNTR_ID", "CNTR_CODE")) {
+    make_sf_filter = function(
+      file_local,
+      values,
+      candidates = c("CNTR_ID", "CNTR_CODE")
+    ) {
       filter_calls[[length(filter_calls) + 1L]] <<- list(
         file_local = file_local,
         values = values,
@@ -80,16 +85,18 @@ test_that("LAU combines country and GISCO ID filters", {
       )
       stats::setNames(list(values), paste(candidates, collapse = "|"))
     },
-    read_gisco_dataset = function(url,
-                                  name,
-                                  cache = TRUE,
-                                  cache_dir = NULL,
-                                  subdir,
-                                  update_cache = FALSE,
-                                  verbose = FALSE,
-                                  filters = NULL,
-                                  operator = "AND",
-                                  ...) {
+    read_gisco_dataset = function(
+      url,
+      name,
+      cache = TRUE,
+      cache_dir = NULL,
+      subdir,
+      update_cache = FALSE,
+      verbose = FALSE,
+      filters = NULL,
+      operator = "AND",
+      ...
+    ) {
       expect_identical(subdir, "lau")
       expect_identical(operator, "OR")
       expect_true(is.function(filters))

--- a/tests/testthat/test-gisco-get-metadata.R
+++ b/tests/testthat/test-gisco-get-metadata.R
@@ -1,6 +1,7 @@
 test_that("Metadata returns NULL when offline", {
   skip_on_cran()
   skip_if_gisco_offline()
+  local_test_cached_db("metadata-db-")
 
   local_mocked_bindings(is_online_fun = function(...) {
     FALSE
@@ -13,11 +14,12 @@ test_that("Metadata returns NULL when offline", {
 test_that("Metadata returns NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
+  local_test_cached_db("metadata-db-")
 
   local_mocked_bindings(is_404 = function(...) {
     TRUE
   })
-  expect_message(n <- gisco_get_metadata(), "Error")
+  expect_snapshot(n <- gisco_get_metadata())
   expect_null(n)
 })
 
@@ -34,7 +36,7 @@ test_that("Metadata helpers build URL and read CSV", {
     "https://example.com/csv/CNTR_AT_2024.csv"
   )
 
-  csv_file <- tempfile(fileext = ".csv")
+  csv_file <- withr::local_tempfile(fileext = ".csv")
   write.csv(
     data.frame(id = "ES", name = "Spain"),
     csv_file,
@@ -61,7 +63,10 @@ test_that("Metadata downloads to the metadata cache", {
     expect_identical(subdir, "gisco_metadata")
     expect_true(verbose)
 
-    csv_file <- tempfile(fileext = ".csv")
+    csv_file <- withr::local_tempfile(
+      fileext = ".csv",
+      .local_envir = testthat::teardown_env()
+    )
     write.csv(
       data.frame(id = "ES", name = "Spain"),
       csv_file,

--- a/tests/testthat/test-gisco-get-nuts.R
+++ b/tests/testthat/test-gisco-get-nuts.R
@@ -1,28 +1,26 @@
 test_that("NUTS return NULL when offline", {
   skip_on_cran()
   skip_if_gisco_offline()
+  local_test_cached_db("nuts-db-")
 
   local_mocked_bindings(is_online_fun = function(...) {
     FALSE
   })
   cdir <- local_test_cache_dir("testnuts-offline-")
-  expect_message(
-    n <- gisco_get_nuts(update_cache = TRUE, cache_dir = cdir, resolution = 60),
-    "No internet"
+  expect_snapshot(
+    n <- gisco_get_nuts(update_cache = TRUE, cache_dir = cdir, resolution = 60)
   )
   expect_null(n)
 })
 test_that("NUTS return NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
+  local_test_cached_db("nuts-db-")
 
   local_mocked_bindings(is_404 = function(...) {
     TRUE
   })
-  expect_message(
-    n <- gisco_get_nuts(update_cache = TRUE, resolution = 60),
-    "Error"
-  )
+  expect_snapshot(n <- gisco_get_nuts(update_cache = TRUE, resolution = 60))
   expect_null(n)
 })
 
@@ -34,16 +32,18 @@ test_that("NUTS use resolved GISCO files", {
         name = "NUTS_RG_60M_2024_4326.gpkg"
       )
     },
-    read_gisco_dataset = function(url,
-                                  name,
-                                  cache = TRUE,
-                                  cache_dir = NULL,
-                                  subdir,
-                                  update_cache = FALSE,
-                                  verbose = FALSE,
-                                  filters = NULL,
-                                  post_process = NULL,
-                                  ...) {
+    read_gisco_dataset = function(
+      url,
+      name,
+      cache = TRUE,
+      cache_dir = NULL,
+      subdir,
+      update_cache = FALSE,
+      verbose = FALSE,
+      filters = NULL,
+      post_process = NULL,
+      ...
+    ) {
       expect_match(url, "NUTS_RG_60M_2024_4326[.]gpkg$")
       expect_identical(name, "NUTS_RG_60M_2024_4326.gpkg")
       expect_false(cache)

--- a/tests/testthat/test-gisco-get-ports.R
+++ b/tests/testthat/test-gisco-get-ports.R
@@ -5,7 +5,7 @@ test_that("Ports return NULL for 404 responses", {
   local_mocked_bindings(is_404 = function(...) {
     TRUE
   })
-  expect_message(n <- gisco_get_ports(update_cache = TRUE), "Error")
+  expect_snapshot(n <- gisco_get_ports(update_cache = TRUE))
   expect_null(n)
 })
 
@@ -49,8 +49,8 @@ test_that("Ports select the 2009 file", {
 })
 
 test_that("Ports download current and legacy point data", {
-  expect_error(gisco_get_ports(year = 2020), "`year` must be")
-  expect_error(gisco_get_ports(year = 2020, country = "ES"), "`year` must be")
+  expect_snapshot(gisco_get_ports(year = 2020), error = TRUE)
+  expect_snapshot(gisco_get_ports(year = 2020, country = "ES"), error = TRUE)
 
   skip_on_cran()
   skip_if_gisco_offline()

--- a/tests/testthat/test-gisco-get-postal-codes.R
+++ b/tests/testthat/test-gisco-get-postal-codes.R
@@ -2,23 +2,26 @@ test_that("Postal codes validate available years", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  expect_error(gisco_get_postal_codes("1991", "Years available for"))
+  expect_snapshot(
+    gisco_get_postal_codes("1991", "Years available for"),
+    error = TRUE
+  )
 })
 
 test_that("Postal codes return NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
+  local_test_cached_db("postal-db-")
 
   local_mocked_bindings(is_404 = function(...) {
     TRUE
   })
-  expect_message(
+  expect_snapshot(
     n <- gisco_get_postal_codes(
       year = 2024,
       country = "ES",
       update_cache = TRUE
-    ),
-    "Error"
+    )
   )
   expect_null(n)
 })
@@ -36,9 +39,11 @@ test_that("Postal codes use resolved GISCO files", {
     convert_country_code_or_null = function(country) {
       c("MT", "LU")
     },
-    make_sf_filter = function(file_local,
-                              values,
-                              candidates = c("CNTR_ID", "CNTR_CODE")) {
+    make_sf_filter = function(
+      file_local,
+      values,
+      candidates = c("CNTR_ID", "CNTR_CODE")
+    ) {
       filter_calls[[length(filter_calls) + 1L]] <<- list(
         file_local = file_local,
         values = values,
@@ -46,15 +51,17 @@ test_that("Postal codes use resolved GISCO files", {
       )
       stats::setNames(list(values), paste(candidates, collapse = "|"))
     },
-    read_gisco_dataset = function(url,
-                                  name,
-                                  cache = TRUE,
-                                  cache_dir = NULL,
-                                  subdir,
-                                  update_cache = FALSE,
-                                  verbose = FALSE,
-                                  filters = NULL,
-                                  ...) {
+    read_gisco_dataset = function(
+      url,
+      name,
+      cache = TRUE,
+      cache_dir = NULL,
+      subdir,
+      update_cache = FALSE,
+      verbose = FALSE,
+      filters = NULL,
+      ...
+    ) {
       expect_match(url, "PCODE_PT_2024_4326[.]gpkg$")
       expect_identical(name, "PCODE_PT_2024_4326.gpkg")
       expect_true(cache)

--- a/tests/testthat/test-gisco-get-unit-country.R
+++ b/tests/testthat/test-gisco-get-unit-country.R
@@ -1,18 +1,18 @@
 test_that("Country unit returns NULL when offline", {
   skip_on_cran()
   skip_if_gisco_offline()
+  local_test_cached_db("unit-country-db-")
 
   local_mocked_bindings(is_online_fun = function(...) {
     FALSE
   })
-  expect_message(
+  expect_snapshot(
     n <- gisco_get_unit_country(
       year = 2024,
       unit = "ES",
       update_cache = TRUE,
       verbose = TRUE
-    ),
-    "No internet"
+    )
   )
   expect_null(n)
 })
@@ -20,18 +20,18 @@ test_that("Country unit returns NULL when offline", {
 test_that("Country unit returns NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
+  local_test_cached_db("unit-country-db-")
 
   local_mocked_bindings(is_404 = function(...) {
     TRUE
   })
-  expect_message(
+  expect_snapshot(
     n <- gisco_get_unit_country(
       year = 2024,
       unit = "ES",
       update_cache = TRUE,
       verbose = TRUE
-    ),
-    "Error"
+    )
   )
   expect_null(n)
 })

--- a/tests/testthat/test-gisco-get-unit-nuts.R
+++ b/tests/testthat/test-gisco-get-unit-nuts.R
@@ -1,13 +1,13 @@
 test_that("NUTS unit returns NULL when offline", {
   skip_on_cran()
   skip_if_gisco_offline()
+  local_test_cached_db("unit-nuts-db-")
 
   local_mocked_bindings(is_online_fun = function(...) {
     FALSE
   })
-  expect_message(
-    n <- gisco_get_unit_nuts(year = 2024, update_cache = TRUE, verbose = TRUE),
-    "No internet"
+  expect_snapshot(
+    n <- gisco_get_unit_nuts(year = 2024, update_cache = TRUE, verbose = TRUE)
   )
   expect_null(n)
 })
@@ -15,13 +15,13 @@ test_that("NUTS unit returns NULL when offline", {
 test_that("NUTS unit returns NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
+  local_test_cached_db("unit-nuts-db-")
 
   local_mocked_bindings(is_404 = function(...) {
     TRUE
   })
-  expect_message(
-    n <- gisco_get_unit_nuts(year = 2024, update_cache = TRUE, verbose = TRUE),
-    "Error"
+  expect_snapshot(
+    n <- gisco_get_unit_nuts(year = 2024, update_cache = TRUE, verbose = TRUE)
   )
   expect_null(n)
 })

--- a/tests/testthat/test-gisco-get-unit-urban-audit.R
+++ b/tests/testthat/test-gisco-get-unit-urban-audit.R
@@ -1,17 +1,17 @@
 test_that("Urban audit unit returns NULL when offline", {
   skip_on_cran()
   skip_if_gisco_offline()
+  local_test_cached_db("unit-urau-db-")
 
   local_mocked_bindings(is_online_fun = function(...) {
     FALSE
   })
-  expect_message(
+  expect_snapshot(
     n <- gisco_get_unit_urban_audit(
       year = 2024,
       update_cache = TRUE,
       verbose = TRUE
-    ),
-    "No internet"
+    )
   )
   expect_null(n)
 })
@@ -19,17 +19,17 @@ test_that("Urban audit unit returns NULL when offline", {
 test_that("Urban audit unit returns NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
+  local_test_cached_db("unit-urau-db-")
 
   local_mocked_bindings(is_404 = function(...) {
     TRUE
   })
-  expect_message(
+  expect_snapshot(
     n <- gisco_get_unit_urban_audit(
       year = 2024,
       update_cache = TRUE,
       verbose = TRUE
-    ),
-    "Error"
+    )
   )
   expect_null(n)
 })

--- a/tests/testthat/test-gisco-get-urban-audit.R
+++ b/tests/testthat/test-gisco-get-urban-audit.R
@@ -2,24 +2,25 @@ test_that("Urban audit validates inputs before remote access", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  expect_error(gisco_get_urban_audit(year = "1999"), "Years available")
-  expect_error(gisco_get_urban_audit(epsg = "9999"), "No results")
-  expect_error(gisco_get_urban_audit(level = "9999"), "`level` must be")
-  expect_error(
+  expect_snapshot(gisco_get_urban_audit(year = "1999"), error = TRUE)
+  expect_snapshot(gisco_get_urban_audit(epsg = "9999"), error = TRUE)
+  expect_snapshot(gisco_get_urban_audit(level = "9999"), error = TRUE)
+  expect_snapshot(
     gisco_get_urban_audit(spatialtype = "BN"),
-    "`spatialtype` must be"
+    error = TRUE
   )
-  expect_error(gisco_get_urban_audit(year = 2001), "No results")
+  expect_snapshot(gisco_get_urban_audit(year = 2001), error = TRUE)
 })
 
 test_that("Urban audit returns NULL for 404 responses", {
   skip_on_cran()
   skip_if_gisco_offline()
+  local_test_cached_db("urau-db-")
 
   local_mocked_bindings(is_404 = function(...) {
     TRUE
   })
-  expect_message(n <- gisco_get_urban_audit(update_cache = TRUE), "Error")
+  expect_snapshot(n <- gisco_get_urban_audit(update_cache = TRUE))
   expect_null(n)
 })
 
@@ -31,16 +32,18 @@ test_that("Urban Audit uses resolved GISCO files", {
         name = "URAU_RG_100K_2024_4326_CITIES.gpkg"
       )
     },
-    read_gisco_dataset = function(url,
-                                  name,
-                                  cache = TRUE,
-                                  cache_dir = NULL,
-                                  subdir,
-                                  update_cache = FALSE,
-                                  verbose = FALSE,
-                                  filters = NULL,
-                                  post_process = NULL,
-                                  ...) {
+    read_gisco_dataset = function(
+      url,
+      name,
+      cache = TRUE,
+      cache_dir = NULL,
+      subdir,
+      update_cache = FALSE,
+      verbose = FALSE,
+      filters = NULL,
+      post_process = NULL,
+      ...
+    ) {
       expect_match(url, "URAU_RG_100K_2024_4326_CITIES[.]gpkg$")
       expect_identical(name, "URAU_RG_100K_2024_4326_CITIES.gpkg")
       expect_false(cache)

--- a/tests/testthat/test-gisco-id-api.R
+++ b/tests/testthat/test-gisco-id-api.R
@@ -20,22 +20,16 @@ test_that("ID API returns NULL for 404 responses", {
   local_mocked_bindings(is_404 = function(...) {
     TRUE
   })
-  expect_message(n <- gisco_id_api_geonames(x = 4, y = 52), "Error")
+  expect_snapshot(n <- gisco_id_api_geonames(x = 4, y = 52))
   expect_null(n)
 
-  expect_message(
-    n <- gisco_id_api_nuts(x = 4, y = 52, geometry = TRUE),
-    "Error"
-  )
+  expect_snapshot(n <- gisco_id_api_nuts(x = 4, y = 52, geometry = TRUE))
   expect_null(n)
 
-  expect_message(n <- gisco_id_api_lau(x = 4, y = 52, geometry = TRUE), "Error")
+  expect_snapshot(n <- gisco_id_api_lau(x = 4, y = 52, geometry = TRUE))
   expect_null(n)
 
-  expect_message(
-    n <- gisco_id_api_country(x = 4, y = 52, geometry = FALSE),
-    "Error"
-  )
+  expect_snapshot(n <- gisco_id_api_country(x = 4, y = 52, geometry = FALSE))
   expect_null(n)
 })
 
@@ -71,12 +65,14 @@ test_that("ID API delegates JSON responses to the JSON helper", {
 
 test_that("ID API spatial reader downloads and reads GeoJSON", {
   local_mocked_bindings(
-    download_url = function(url,
-                            name,
-                            cache_dir,
-                            subdir,
-                            update_cache = FALSE,
-                            verbose = FALSE) {
+    download_url = function(
+      url,
+      name,
+      cache_dir,
+      subdir,
+      update_cache = FALSE,
+      verbose = FALSE
+    ) {
       expect_identical(url, "https://example.com/file.geojson")
       expect_match(name, "[.]geojson$")
       expect_identical(cache_dir, tempdir())

--- a/tests/testthat/test-utils-url.R
+++ b/tests/testthat/test-utils-url.R
@@ -67,10 +67,12 @@ test_that("Dataset reader delegates cache and non-cache paths", {
     download_url = function(...) {
       "cached.gpkg"
     },
-    read_geo_file_sf_filtered = function(file_local,
-                                         filters = NULL,
-                                         operator = "AND",
-                                         verbose = FALSE) {
+    read_geo_file_sf_filtered = function(
+      file_local,
+      filters = NULL,
+      operator = "AND",
+      verbose = FALSE
+    ) {
       data.frame(source = file_local, operator = operator)
     }
   )
@@ -286,11 +288,14 @@ test_that("URL database lookup validates and returns matching entries", {
   skip_on_cran()
   skip_if_gisco_offline()
 
-  expect_error(get_url_db(
-    "postal_codes",
-    year = "1991",
-    fn = "gisco_get_postalcodes"
-  ))
+  expect_snapshot(
+    get_url_db(
+      "postal_codes",
+      year = "1991",
+      fn = "gisco_get_postalcodes"
+    ),
+    error = TRUE
+  )
 
   expect_snapshot(
     get_url_db("communes", "9999", fn = "gisco_get_communes"),

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -85,8 +85,8 @@ test_that("Argument matching reports invalid values", {
     match_arg_pretty(year)
   }
 
-  expect_error(match_year(2030), "must be")
-  expect_error(match_year(c(2020, 2030)), "must be")
+  expect_snapshot(match_year(2030), error = TRUE)
+  expect_snapshot(match_year(c(2020, 2030)), error = TRUE)
 })
 
 test_that("Resolution format helpers work", {
@@ -110,7 +110,7 @@ test_that("rbind_fill combines sf inputs with different schemas", {
   gb <- giscoR::gisco_countries_2024[1, ]
   cos <- giscoR::gisco_nuts_2024[1, ]
   a_list <- list(gb, cos, gb, cos)
-  expect_error(err <- do.call(rbind, a_list))
+  expect_snapshot(err <- do.call(rbind, a_list), error = TRUE)
   expect_silent(binded <- rbind_fill(a_list))
   expect_s3_class(binded, "sf")
   expect_s3_class(binded, "tbl_df")
@@ -125,7 +125,7 @@ test_that("rbind_fill combines tibble inputs with different schemas", {
   cos <- giscoR::gisco_nuts_2024[1, ]
   cos <- sf::st_drop_geometry(cos)
   a_list <- list(gb, cos, gb, cos)
-  expect_error(err <- do.call(rbind, a_list))
+  expect_snapshot(err <- do.call(rbind, a_list), error = TRUE)
   expect_silent(binded <- rbind_fill(a_list))
   expect_s3_class(binded, "tbl_df")
   expect_equal(nrow(binded), 4)
@@ -138,7 +138,7 @@ test_that("rbind_fill drops NULL entries from sf input lists", {
   cos <- giscoR::gisco_nuts_2024[1, ]
   a_list <- list(gb, cos, gb, cos)
   a_list[[3]] <- NULL
-  expect_error(err <- do.call(rbind, a_list))
+  expect_snapshot(err <- do.call(rbind, a_list), error = TRUE)
   expect_silent(binded <- rbind_fill(a_list))
   expect_s3_class(binded, "sf")
   expect_s3_class(binded, "tbl_df")
@@ -155,7 +155,7 @@ test_that("rbind_fill drops NULL entries from tibble input lists", {
 
   a_list <- list(gb, cos, gb, cos)
   a_list[[3]] <- NULL
-  expect_error(err <- do.call(rbind, a_list))
+  expect_snapshot(err <- do.call(rbind, a_list), error = TRUE)
   expect_silent(binded <- rbind_fill(a_list))
   expect_s3_class(binded, "tbl_df")
   expect_equal(nrow(binded), 3)


### PR DESCRIPTION
## What changed

- Aligns tests with the repository AGENTS.md guidance by preferring snapshots for stable messages and errors.
- Adds snapshot coverage for validation, offline and 404 branches across GISCO dataset helpers.
- Adds a test helper that seeds a local cached GISCO DB so offline/404 tests do not depend on prior cache state.
- Includes the full current worktree as requested, including the existing `.github` and `DESCRIPTION` changes.

## Why

The previous tests mixed partial `expect_message()` / `expect_error()` checks with snapshot tests. This made some behavior less reviewable and allowed cache-state fallback messages to leak into unrelated snapshots.

## Validation

- `air format .`
- `Rscript -e "devtools::load_all(); devtools::lint()"`
- `jarl check .`
- Focused `devtools::test()` / `devtools::test_active_file()` runs for the touched tests and snapshot blocks.

## Notes

Coverage was intentionally not run per follow-up instruction.