### PR TITLE
Allow GISCO timeout envvar configuration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 - Add a precomputed article showing GISCO ID service API and GISCO Address API
   workflows with **ggplot2** examples.
 - `gisco_get_airports()` adds support for the Airports 2024 point dataset.
+- Query timeout can now also be controlled with the `GISCO_TIMEOUT` environment
+  variable when `options(gisco_timeout)` is not set.
 - Update `?gisco_db`.
 - `gisco_get_postal_codes()` now defaults to the 2025 release and adds an `epsg`
   argument.

--- a/R/utils-request.R
+++ b/R/utils-request.R
@@ -27,7 +27,7 @@ gisco_request <- function(
   req <- httr2::req_error(req, is_error = function(x) {
     FALSE
   })
-  req <- httr2::req_timeout(req, getOption("gisco_timeout", 300L))
+  req <- httr2::req_timeout(req, gisco_timeout())
 
   if (cache) {
     req <- httr2::req_cache(
@@ -196,4 +196,31 @@ call_gisco_json_api <- function(
 #' @noRd
 gisco_resp_body_json <- function(resp, ...) {
   httr2::resp_body_json(resp, ...)
+}
+
+#' Get an HTTP configuration value from options or environment variables
+#' @noRd
+gisco_http_config <- function(option, envvar, default) {
+  opt <- getOption(option, NULL)
+  if (!is.null(opt)) {
+    return(opt)
+  }
+
+  env <- Sys.getenv(envvar, unset = NA_character_)
+  if (is.na(env) || identical(env, "")) {
+    return(default)
+  }
+
+  env_num <- suppressWarnings(as.numeric(env))
+  if (is.na(env_num)) {
+    return(default)
+  }
+
+  env_num
+}
+
+#' Get the timeout setting for GISCO HTTP requests
+#' @noRd
+gisco_timeout <- function() {
+  gisco_http_config("gisco_timeout", "GISCO_TIMEOUT", 300L)
 }

--- a/tests/testthat/test-utils-request.R
+++ b/tests/testthat/test-utils-request.R
@@ -1,0 +1,32 @@
+test_that("HTTP settings can be controlled with environment variables", {
+  withr::local_options(gisco_timeout = NULL)
+  withr::local_envvar(GISCO_TIMEOUT = "600")
+
+  expect_equal(gisco_timeout(), 600)
+
+  withr::local_envvar(GISCO_TIMEOUT = NA)
+  expect_equal(gisco_timeout(), 300L)
+
+  withr::local_envvar(GISCO_TIMEOUT = "invalid")
+  expect_equal(gisco_timeout(), 300L)
+})
+
+test_that("HTTP options take precedence over environment variables", {
+  withr::local_options(gisco_timeout = 30)
+  withr::local_envvar(GISCO_TIMEOUT = "600")
+
+  expect_equal(gisco_timeout(), 30)
+})
+
+test_that("HTTP setting environment variables are used in requests", {
+  withr::local_options(gisco_timeout = NULL)
+  withr::local_envvar(GISCO_TIMEOUT = "600")
+
+  req <- gisco_request(
+    "https://example.com",
+    cache = FALSE,
+    retry = FALSE
+  )
+
+  expect_equal(req$options$timeout_ms, 600000)
+})


### PR DESCRIPTION
## Summary

This PR lets GISCO HTTP request timeout configuration be controlled with the `GISCO_TIMEOUT` environment variable when `options(gisco_timeout)` is not set.

`options(gisco_timeout)` keeps precedence over the environment variable, and invalid or unset environment values fall back to the existing 300 second default.

## Validation

- `devtools::test(filter = '^utils-request')`
- `devtools::test_coverage_active_file('R/utils-request.R')`
- `devtools::load_all(); devtools::lint()`
- `jarl check .`
